### PR TITLE
Simplify explanation of available Ubuntu packages

### DIFF
--- a/_docs/repositories
+++ b/_docs/repositories
@@ -42,8 +42,10 @@ release of i3. To use it, run the following commands:
 # apt-get install i3
 ---------------------------------------------------------------------------------
 
-The following Ubuntu versions are currently available: oneiric, precise, quantal,
-raring, saucy, trusty.
+All Ubuntu versions which are currently supported by Ubuntu itself are also supported by
+this repository. See link:https://wiki.ubuntu.com/Releases[Ubuntu releases] for details.
+
+Packages for unsupported Ubuntu versions might exist but may disappear any time.
 
 === Development releases
 

--- a/docs/repositories.html
+++ b/docs/repositories.html
@@ -4,7 +4,7 @@
 <head>
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.9" />
 <title>i3: Debian and Ubuntu repositories</title>
 <link rel="stylesheet" href="/css/style.css" type="text/css" />
 <link rel="stylesheet" href="/css/xhtml11.css" type="text/css" />
@@ -94,8 +94,9 @@ release of i3. To use it, run the following commands:</p></div>
 # apt-get update
 # apt-get install i3</tt></pre>
 </div></div>
-<div class="paragraph"><p>The following Ubuntu versions are currently available: oneiric, precise, quantal,
-raring, saucy, trusty.</p></div>
+<div class="paragraph"><p>All Ubuntu versions which are currently supported by Ubuntu itself are also supported by
+this repository. See <a href="https://wiki.ubuntu.com/Releases">Ubuntu releases</a> for details.</p></div>
+<div class="paragraph"><p>Packages for unsupported Ubuntu versions might exist but may disappear any time.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_development_releases">2.2. Development releases</h3>


### PR DESCRIPTION
Listing each supported Ubuntu release explicitely is cumbersome and
error-prone. Use a more timeless explanation.