### PR TITLE
Fix OpenBSD download link

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -23,7 +23,7 @@ currently distributed in the following operating systems/distributions:
 {% include downloadlogo.html title="FreeBSD" link="http://www.freebsd.org/cgi/cvsweb.cgi/ports/x11-wm/i3/" img="/img/freebsd.png" height=59 %}
 {% include downloadlogo.html title="NetBSD" link="http://pkgsrc.se/wm/i3" img="/img/netbsd_logo.svg" height=56 %}
 <br>
-{% include downloadlogo.html title="OpenBSD" link="http://www.openbsd.org/cgi-bin/cvsweb/ports/x11/i3/" img="/img/Openbsd2.png" height=49 %}
+{% include downloadlogo.html title="OpenBSD" link="http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/x11/i3/" img="/img/Openbsd2.png" height=49 %}
 {% include downloadlogo.html title="openSUSE" link="http://software.opensuse.org/package/i3" img="/img/opensuse.svg" height=48 %}
 {% include downloadlogo.html title="Mageia" link="http://mageia.madb.org/package/show/application/0/name/i3" img="/img/mageia.png" height=85 %}
 {% include downloadlogo.html title="Fedora" link="https://admin.fedoraproject.org/pkgdb/package/i3/" img="/img/fedora.svg" height=75 %}


### PR DESCRIPTION
Apparently the cvsweb instance has moved to a dedicated subdomain. The old address just redirects to the CVS root.