### PR TITLE
Update style.css

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -394,6 +394,7 @@ table#downloads tbody tr:first-child {
     padding-right: 0.5em;
     white-space: pre;
     color: white;
+    overflow: auto;
 }
 
 .usergen tt {


### PR DESCRIPTION
[The overflow property specifies what happens if content overflows an element's box. If overflow is clipped, a scroll-bar should be added to see the rest of the content.](http://www.w3schools.com/cssref/pr_pos_overflow.asp)

Affected [page](http://i3wm.org/docs/user-contributed/workspace-current-output.html), there could be more but I gave this one as example when the overflow is not set to auto.

Consider making your website mobile [friendly](http://mobiletest.me/) too.