### PR TITLE
The easiest way to resize a container is by using the keyboard

### DIFF
--- a/_docs/i3-config-wizard.man
+++ b/_docs/i3-config-wizard.man
@@ -28,7 +28,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.
 

--- a/_docs/i3.man
+++ b/_docs/i3.man
@@ -92,7 +92,7 @@ are connected to these outputs.
 Here is a short overview of the default keybindings:
 
 j/k/l/;::
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 
 Mod1+<direction>::

--- a/_docs/i3.man
+++ b/_docs/i3.man
@@ -233,7 +233,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/_docs/refcard.html
+++ b/_docs/refcard.html
@@ -173,7 +173,7 @@
                         <td>reload the configuration file
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>e</kbd>

--- a/_docs/testsuite
+++ b/_docs/testsuite
@@ -13,8 +13,8 @@ interest for end users.
 
 The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.
 
@@ -24,7 +24,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.
 

--- a/_docs/userguide
+++ b/_docs/userguide
@@ -2210,7 +2210,7 @@ shmlog on|off|toggle
 # Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))
 ---------------

--- a/_docs/userguide
+++ b/_docs/userguide
@@ -149,7 +149,7 @@ it does not yet exist.
 By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.
 
-See <<resizingconfig>> for how to configure i3 to be able to resize
+See <<resizing_containers>> for how to configure i3 to be able to resize
 columns/rows with your keyboard.
 
 === Restarting i3 in place
@@ -177,7 +177,7 @@ around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <<floating_modifier>>. Another way to resize
 floating windows using the mouse is to right-click on the titlebar and drag.
 
-For resizing floating windows with your keyboard, see <<resizingconfig>>.
+For resizing floating windows with your keyboard, see <<resizing_containers>>.
 
 Floating windows are always on top of tiling windows.
 
@@ -1452,7 +1452,7 @@ bar {
 Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a +mode+ definition, see <<resizingconfig>>.
+For an example of a +mode+ definition, see <<resizing_containers>>.
 
 The default is to show the mode indicator.
 
@@ -1993,7 +1993,7 @@ move window|container to mark <mark>
 for_window [instance="tabme"] move window to mark target
 --------------------------------------------------------
 
-[[resizingconfig]]
+[[resizing_containers]]
 
 === Resizing containers/windows
 

--- a/_docs/userguide
+++ b/_docs/userguide
@@ -118,7 +118,7 @@ provide a menu, the escape key or a shortcut like +Control+W+ to close), you
 can press +$mod+Shift+q+ to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.
 
 === Using workspaces

--- a/_docs/userguide
+++ b/_docs/userguide
@@ -21,7 +21,7 @@ image:keyboard-layer1.png["Keys to use with $mod (Alt)",width=600,link="keyboard
 image:keyboard-layer2.png["Keys to use with Shift+$mod",width=600,link="keyboard-layer2.png"]
 
 The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.
+are your home row.
 
 Note that when starting i3 without a config file, i3-config-wizard will offer
 you to create a config file in which the key positions (!) match what you see
@@ -53,7 +53,7 @@ existing window (rotated displays).
 image:two_terminals.png[Two terminals]
 
 To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor +vi+. However, in i3, your homerow is used
+which you may know from the editor +vi+. However, in i3, your home row is used
 for these keys (in +vi+, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, +$mod+J+ is left, +$mod+K+
 is down, +$mod+L+ is up and `$mod+;` is right. So, to switch between the

--- a/_docs/userguide
+++ b/_docs/userguide
@@ -146,7 +146,7 @@ it does not yet exist.
 
 === Resizing
 
-The easiest way to resize a container is by using the mouse: Grab the border
+By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.
 
 See <<resizingconfig>> for how to configure i3 to be able to resize

--- a/_docs/userguide
+++ b/_docs/userguide
@@ -152,7 +152,7 @@ and move it to the wanted size.
 See <<resizingconfig>> for how to configure i3 to be able to resize
 columns/rows with your keyboard.
 
-=== Restarting i3 inplace
+=== Restarting i3 in place
 
 To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use +$mod+Shift+r+.
@@ -2236,7 +2236,7 @@ bindsym $mod+x debuglog toggle
 === Reloading/Restarting/Exiting
 
 You can make i3 reload its configuration file with +reload+. You can also
-restart i3 inplace with the +restart+ command to get it out of some weird state
+restart i3 in place with the +restart+ command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the +exit+ command,
 however you don’t need to (simply killing your X session is fine as well).

--- a/docs/3.e/hacking-howto.html
+++ b/docs/3.e/hacking-howto.html
@@ -856,7 +856,7 @@ Forgetting to call <tt>xcb_flush(conn);</tt> after sending a request. This usual
 <h2 id="_using_git_sending_patches">17. Using git / sending patches</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>For a short introduction into using git, see
-<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or, for more documentation, see
+<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or for more documentation, see
 <a href="http://git-scm.com/documentation">http://git-scm.com/documentation</a></p></div>
 <div class="paragraph"><p>When you want to send a patch because you fixed a bug or implemented a cool
 feature (please talk to us before working on features to see whether they are

--- a/docs/3.e/i3.html
+++ b/docs/3.e/i3.html
@@ -201,7 +201,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/3.e/i3.html
+++ b/docs/3.e/i3.html
@@ -382,7 +382,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/3.e/manpage.html
+++ b/docs/3.e/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/3.e/manpage.html
+++ b/docs/3.e/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/3.e/userguide.html
+++ b/docs/3.e/userguide.html
@@ -201,8 +201,8 @@ cells one above the other.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
-<div class="paragraph"><p>To restart i3 inplace (and thus get into a clean state if there is a bug, or
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
+<div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>Mod1+Shift+r</tt>. Be aware,
 though, that this kills your current layout and all the windows you have opened
 will be put in a default container in only one cell. Saving layouts will be
@@ -912,7 +912,7 @@ stack-limit rows 5</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">4.10. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. However, your layout is not preserved at the moment, meaning
 that all open windows will end up in a single container in default layout

--- a/docs/3.e/userguide.html
+++ b/docs/3.e/userguide.html
@@ -166,7 +166,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>Mod1+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/3.e/userguide.html
+++ b/docs/3.e/userguide.html
@@ -65,7 +65,7 @@ keybindings (click to see the full size image):</p></div>
 keyboard layout you actually use. The key positions are what matters (of course
 you can also use keysymbols, see <a href="#keybindings">[keybindings]</a>).</p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -92,7 +92,7 @@ the size of the cell that holds them.</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you use the direction keys which
-you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used for
+you may know from the editor <tt>vi</tt>. However, in i3, your home row is used for
 these keys (in <tt>vi</tt>, the keys are shifted to the left by one for compatibility
 with most keyboard layouts). Therefore, <tt>Mod1+J</tt> is left, <tt>Mod1+K</tt> is down,
 <tt>Mod1+L</tt> is up and <tt>Mod1+;</tt> is right. So, to switch between the terminals,

--- a/docs/3.e/userguide.html
+++ b/docs/3.e/userguide.html
@@ -197,7 +197,7 @@ and move it to the wanted size. Please keep in mind that each cell of the table
 holds a <tt>container</tt> and thus you cannot horizontally resize single windows.  If
 you need applications with different horizontal sizes, place them in seperate
 cells one above the other.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -234,7 +234,7 @@ windows, or toolbar windows (GIMP or similar).</p></div>
 dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -743,7 +743,7 @@ bindsym Mod1+p pw</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">4.4. Resizing columns/rows</h3>
+<h3 id="resizing_containers">4.4. Resizing columns/rows</h3>
 <div class="paragraph"><p>If you want to resize columns/rows using your keyboard, you can use the
 <tt>resize</tt> command, I recommend using it inside a so called <tt>mode</tt>:</p></div>
 <div class="listingblock">

--- a/docs/4.0/hacking-howto.html
+++ b/docs/4.0/hacking-howto.html
@@ -1012,7 +1012,7 @@ Forgetting to call <tt>xcb_flush(conn);</tt> after sending a request. This usual
 <h2 id="_using_git_sending_patches">19. Using git / sending patches</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>For a short introduction into using git, see
-<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or, for more documentation, see
+<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or for more documentation, see
 <a href="http://git-scm.com/documentation">http://git-scm.com/documentation</a></p></div>
 <div class="paragraph"><p>When you want to send a patch because you fixed a bug or implemented a cool
 feature (please talk to us before working on features to see whether they are

--- a/docs/4.0/i3-config-wizard.html
+++ b/docs/4.0/i3-config-wizard.html
@@ -70,7 +70,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.0/i3.html
+++ b/docs/4.0/i3.html
@@ -424,7 +424,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.0/i3.html
+++ b/docs/4.0/i3.html
@@ -197,7 +197,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.0/userguide.html
+++ b/docs/4.0/userguide.html
@@ -193,7 +193,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -216,7 +216,7 @@ appropriate hint and are opened in floating mode by default.</p></div>
 dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1025,7 +1025,7 @@ will order them numerically.</p></div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">5.5. Resizing containers/windows</h3>
+<h3 id="resizing_containers">5.5. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.0/userguide.html
+++ b/docs/4.0/userguide.html
@@ -191,7 +191,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.0/userguide.html
+++ b/docs/4.0/userguide.html
@@ -62,7 +62,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -88,7 +88,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>mod+J</tt> is left, <tt>mod+K</tt>
 is down, <tt>mod+L</tt> is up and <tt>mod+;</tt> is right. So, to switch between the

--- a/docs/4.0/userguide.html
+++ b/docs/4.0/userguide.html
@@ -165,7 +165,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">
@@ -454,7 +454,7 @@ you hold the shift button as well, the resize will be proportional.</p></div>
 (anything wider than high) get horizontal orientation, rotated monitors
 (anything higher than wide) get vertical orientation.</p></div>
 <div class="paragraph"><p>With the <tt>default_orientation</tt> configuration directive, you can override that
-behaviour.</p></div>
+behavior.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
 <div class="content">
@@ -761,7 +761,7 @@ Leave fullscreen mode. This is the default.
 <div class="paragraph"><p>When being in a tabbed or stacked container, the first container will be
 focused when you use <tt>focus down</tt> on the last container&#8201;&#8212;&#8201;the focus wraps. If
 however there is another stacked/tabbed container in that direction, focus will
-be set on that container. This is the default behaviour so you can navigate to
+be set on that container. This is the default behavior so you can navigate to
 all your windows without having to use <tt>focus parent</tt>.</p></div>
 <div class="paragraph"><p>If you want the focus to <strong>always</strong> wrap and you are aware of using <tt>focus
 parent</tt> to switch to different containers, you can use the

--- a/docs/4.0/userguide.html
+++ b/docs/4.0/userguide.html
@@ -197,8 +197,8 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
-<div class="paragraph"><p>To restart i3 inplace (and thus get into a clean state if there is a bug, or
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
+<div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>mod+Shift+r</tt>.</p></div>
 </div>
 <div class="sect2">
@@ -1133,7 +1133,7 @@ bindsym mod+u border none</tt></pre>
 <div class="sect2">
 <h3 id="stack-limit">5.9. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.10.1/i3-config-wizard.html
+++ b/docs/4.10.1/i3-config-wizard.html
@@ -71,7 +71,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.10.1/i3.html
+++ b/docs/4.10.1/i3.html
@@ -198,7 +198,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.10.1/i3.html
+++ b/docs/4.10.1/i3.html
@@ -425,7 +425,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.10.1/manpage.html
+++ b/docs/4.10.1/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.10.1/manpage.html
+++ b/docs/4.10.1/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.10.1/refcard.html
+++ b/docs/4.10.1/refcard.html
@@ -173,7 +173,7 @@
                         <td>reload the configuration file
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.10.1/testsuite.html
+++ b/docs/4.10.1/testsuite.html
@@ -51,8 +51,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -61,7 +61,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.10.1/userguide.html
+++ b/docs/4.10.1/userguide.html
@@ -194,7 +194,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.10.1/userguide.html
+++ b/docs/4.10.1/userguide.html
@@ -196,7 +196,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -222,7 +222,7 @@ dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>. Another way to resize
 floating windows using the mouse is to right-click on the titlebar and drag.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1386,7 +1386,7 @@ workspaces to "1:I", "2:II", "3:III", "4:IV", &#8230;</p></div>
 <div class="paragraph"><p>Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a <tt>mode</tt> definition, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+For an example of a <tt>mode</tt> definition, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>The default is to show the mode indicator.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
@@ -1944,7 +1944,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.10.1/userguide.html
+++ b/docs/4.10.1/userguide.html
@@ -168,7 +168,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/4.10.1/userguide.html
+++ b/docs/4.10.1/userguide.html
@@ -200,7 +200,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -2098,7 +2098,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.14. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.10.1/userguide.html
+++ b/docs/4.10.1/userguide.html
@@ -63,7 +63,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -89,7 +89,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.10.1/userguide.html
+++ b/docs/4.10.1/userguide.html
@@ -2072,7 +2072,7 @@ shmlog &lt;on|off|toggle&gt;</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/4.10.2/i3-config-wizard.html
+++ b/docs/4.10.2/i3-config-wizard.html
@@ -71,7 +71,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.10.2/i3.html
+++ b/docs/4.10.2/i3.html
@@ -198,7 +198,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.10.2/i3.html
+++ b/docs/4.10.2/i3.html
@@ -425,7 +425,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.10.2/manpage.html
+++ b/docs/4.10.2/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.10.2/manpage.html
+++ b/docs/4.10.2/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.10.2/refcard.html
+++ b/docs/4.10.2/refcard.html
@@ -173,7 +173,7 @@
                         <td>reload the configuration file
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.10.2/testsuite.html
+++ b/docs/4.10.2/testsuite.html
@@ -51,8 +51,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -61,7 +61,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.10.2/userguide.html
+++ b/docs/4.10.2/userguide.html
@@ -194,7 +194,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.10.2/userguide.html
+++ b/docs/4.10.2/userguide.html
@@ -168,7 +168,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/4.10.2/userguide.html
+++ b/docs/4.10.2/userguide.html
@@ -200,7 +200,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -2097,7 +2097,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.14. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.10.2/userguide.html
+++ b/docs/4.10.2/userguide.html
@@ -63,7 +63,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -89,7 +89,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.10.2/userguide.html
+++ b/docs/4.10.2/userguide.html
@@ -2071,7 +2071,7 @@ shmlog &lt;on|off|toggle&gt;</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/4.10.2/userguide.html
+++ b/docs/4.10.2/userguide.html
@@ -196,7 +196,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -222,7 +222,7 @@ dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>. Another way to resize
 floating windows using the mouse is to right-click on the titlebar and drag.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1385,7 +1385,7 @@ workspaces to "1:I", "2:II", "3:III", "4:IV", &#8230;</p></div>
 <div class="paragraph"><p>Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a <tt>mode</tt> definition, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+For an example of a <tt>mode</tt> definition, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>The default is to show the mode indicator.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
@@ -1943,7 +1943,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.10.3/i3-config-wizard.html
+++ b/docs/4.10.3/i3-config-wizard.html
@@ -71,7 +71,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.10.3/i3.html
+++ b/docs/4.10.3/i3.html
@@ -198,7 +198,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.10.3/i3.html
+++ b/docs/4.10.3/i3.html
@@ -425,7 +425,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.10.3/manpage.html
+++ b/docs/4.10.3/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.10.3/manpage.html
+++ b/docs/4.10.3/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.10.3/refcard.html
+++ b/docs/4.10.3/refcard.html
@@ -173,7 +173,7 @@
                         <td>reload the configuration file
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.10.3/testsuite.html
+++ b/docs/4.10.3/testsuite.html
@@ -51,8 +51,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -61,7 +61,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.10.3/userguide.html
+++ b/docs/4.10.3/userguide.html
@@ -194,7 +194,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.10.3/userguide.html
+++ b/docs/4.10.3/userguide.html
@@ -200,7 +200,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -2103,7 +2103,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.14. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.10.3/userguide.html
+++ b/docs/4.10.3/userguide.html
@@ -168,7 +168,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/4.10.3/userguide.html
+++ b/docs/4.10.3/userguide.html
@@ -63,7 +63,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -89,7 +89,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.10.3/userguide.html
+++ b/docs/4.10.3/userguide.html
@@ -2077,7 +2077,7 @@ shmlog &lt;on|off|toggle&gt;</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/4.10.3/userguide.html
+++ b/docs/4.10.3/userguide.html
@@ -196,7 +196,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -222,7 +222,7 @@ dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>. Another way to resize
 floating windows using the mouse is to right-click on the titlebar and drag.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1388,7 +1388,7 @@ workspaces to "1:I", "2:II", "3:III", "4:IV", &#8230;</p></div>
 <div class="paragraph"><p>Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a <tt>mode</tt> definition, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+For an example of a <tt>mode</tt> definition, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>The default is to show the mode indicator.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
@@ -1949,7 +1949,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.10.4/i3-config-wizard.html
+++ b/docs/4.10.4/i3-config-wizard.html
@@ -71,7 +71,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.10.4/i3.html
+++ b/docs/4.10.4/i3.html
@@ -198,7 +198,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.10.4/i3.html
+++ b/docs/4.10.4/i3.html
@@ -425,7 +425,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.10.4/manpage.html
+++ b/docs/4.10.4/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.10.4/manpage.html
+++ b/docs/4.10.4/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.10.4/refcard.html
+++ b/docs/4.10.4/refcard.html
@@ -173,7 +173,7 @@
                         <td>reload the configuration file
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.10.4/testsuite.html
+++ b/docs/4.10.4/testsuite.html
@@ -51,8 +51,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -61,7 +61,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.10.4/userguide.html
+++ b/docs/4.10.4/userguide.html
@@ -194,7 +194,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.10.4/userguide.html
+++ b/docs/4.10.4/userguide.html
@@ -200,7 +200,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -2103,7 +2103,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.14. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.10.4/userguide.html
+++ b/docs/4.10.4/userguide.html
@@ -168,7 +168,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/4.10.4/userguide.html
+++ b/docs/4.10.4/userguide.html
@@ -63,7 +63,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -89,7 +89,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.10.4/userguide.html
+++ b/docs/4.10.4/userguide.html
@@ -2077,7 +2077,7 @@ shmlog &lt;on|off|toggle&gt;</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/4.10.4/userguide.html
+++ b/docs/4.10.4/userguide.html
@@ -196,7 +196,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -222,7 +222,7 @@ dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>. Another way to resize
 floating windows using the mouse is to right-click on the titlebar and drag.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1388,7 +1388,7 @@ workspaces to "1:I", "2:II", "3:III", "4:IV", &#8230;</p></div>
 <div class="paragraph"><p>Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a <tt>mode</tt> definition, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+For an example of a <tt>mode</tt> definition, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>The default is to show the mode indicator.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
@@ -1949,7 +1949,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.10/i3-config-wizard.html
+++ b/docs/4.10/i3-config-wizard.html
@@ -71,7 +71,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.10/i3.html
+++ b/docs/4.10/i3.html
@@ -198,7 +198,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.10/i3.html
+++ b/docs/4.10/i3.html
@@ -425,7 +425,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.10/manpage.html
+++ b/docs/4.10/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.10/manpage.html
+++ b/docs/4.10/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.10/refcard.html
+++ b/docs/4.10/refcard.html
@@ -173,7 +173,7 @@
                         <td>reload the configuration file
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.10/testsuite.html
+++ b/docs/4.10/testsuite.html
@@ -51,8 +51,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -61,7 +61,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.10/userguide.html
+++ b/docs/4.10/userguide.html
@@ -194,7 +194,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.10/userguide.html
+++ b/docs/4.10/userguide.html
@@ -196,7 +196,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -222,7 +222,7 @@ dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>. Another way to resize
 floating windows using the mouse is to right-click on the titlebar and drag.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1386,7 +1386,7 @@ workspaces to "1:I", "2:II", "3:III", "4:IV", &#8230;</p></div>
 <div class="paragraph"><p>Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a <tt>mode</tt> definition, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+For an example of a <tt>mode</tt> definition, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>The default is to show the mode indicator.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
@@ -1944,7 +1944,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.10/userguide.html
+++ b/docs/4.10/userguide.html
@@ -168,7 +168,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/4.10/userguide.html
+++ b/docs/4.10/userguide.html
@@ -200,7 +200,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -2098,7 +2098,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.14. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.10/userguide.html
+++ b/docs/4.10/userguide.html
@@ -63,7 +63,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -89,7 +89,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.10/userguide.html
+++ b/docs/4.10/userguide.html
@@ -2072,7 +2072,7 @@ shmlog &lt;on|off|toggle&gt;</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/4.2/hacking-howto.html
+++ b/docs/4.2/hacking-howto.html
@@ -1486,7 +1486,7 @@ Forgetting to call <tt>floating_fix_coordinates(con, old_rect, new_rect)</tt> af
 <h2 id="_using_git_sending_patches">20. Using git / sending patches</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>For a short introduction into using git, see
-<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or, for more documentation, see
+<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or for more documentation, see
 <a href="http://git-scm.com/documentation">http://git-scm.com/documentation</a></p></div>
 <div class="paragraph"><p>When you want to send a patch because you fixed a bug or implemented a cool
 feature (please talk to us before working on features to see whether they are

--- a/docs/4.2/i3-config-wizard.html
+++ b/docs/4.2/i3-config-wizard.html
@@ -70,7 +70,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.2/i3.html
+++ b/docs/4.2/i3.html
@@ -424,7 +424,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.2/i3.html
+++ b/docs/4.2/i3.html
@@ -197,7 +197,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.2/manpage.html
+++ b/docs/4.2/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.2/manpage.html
+++ b/docs/4.2/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.2/refcard.html
+++ b/docs/4.2/refcard.html
@@ -148,7 +148,7 @@
 	<table>
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.2/testsuite.html
+++ b/docs/4.2/testsuite.html
@@ -50,8 +50,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -60,7 +60,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.2/userguide.html
+++ b/docs/4.2/userguide.html
@@ -165,7 +165,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">
@@ -477,7 +477,7 @@ floating_maximum_size -1 x -1</tt></pre>
 (anything wider than high) get horizontal orientation, rotated monitors
 (anything higher than wide) get vertical orientation.</p></div>
 <div class="paragraph"><p>With the <tt>default_orientation</tt> configuration directive, you can override that
-behaviour.</p></div>
+behavior.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
 <div class="content">
@@ -818,7 +818,7 @@ Leave fullscreen mode. This is the default.
 <div class="paragraph"><p>When being in a tabbed or stacked container, the first container will be
 focused when you use <tt>focus down</tt> on the last container&#8201;&#8212;&#8201;the focus wraps. If
 however there is another stacked/tabbed container in that direction, focus will
-be set on that container. This is the default behaviour so you can navigate to
+be set on that container. This is the default behavior so you can navigate to
 all your windows without having to use <tt>focus parent</tt>.</p></div>
 <div class="paragraph"><p>If you want the focus to <strong>always</strong> wrap and you are aware of using <tt>focus
 parent</tt> to switch to different containers, you can use the

--- a/docs/4.2/userguide.html
+++ b/docs/4.2/userguide.html
@@ -197,8 +197,8 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
-<div class="paragraph"><p>To restart i3 inplace (and thus get into a clean state if there is a bug, or
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
+<div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>mod+Shift+r</tt>.</p></div>
 </div>
 <div class="sect2">
@@ -1670,7 +1670,7 @@ bindsym mod+u border none</tt></pre>
 <div class="sect2">
 <h3 id="stack-limit">6.11. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.2/userguide.html
+++ b/docs/4.2/userguide.html
@@ -191,7 +191,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.2/userguide.html
+++ b/docs/4.2/userguide.html
@@ -62,7 +62,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -88,7 +88,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>mod+J</tt> is left, <tt>mod+K</tt>
 is down, <tt>mod+L</tt> is up and <tt>mod+;</tt> is right. So, to switch between the

--- a/docs/4.2/userguide.html
+++ b/docs/4.2/userguide.html
@@ -193,7 +193,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -216,7 +216,7 @@ appropriate hint and are opened in floating mode by default.</p></div>
 dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1561,7 +1561,7 @@ i3-msg 'rename workspace "1: www" to "10: www"'</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.7. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.7. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.3/hacking-howto.html
+++ b/docs/4.3/hacking-howto.html
@@ -1486,7 +1486,7 @@ Forgetting to call <tt>floating_fix_coordinates(con, old_rect, new_rect)</tt> af
 <h2 id="_using_git_sending_patches">20. Using git / sending patches</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>For a short introduction into using git, see
-<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or, for more documentation, see
+<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or for more documentation, see
 <a href="http://git-scm.com/documentation">http://git-scm.com/documentation</a></p></div>
 <div class="paragraph"><p>When you want to send a patch because you fixed a bug or implemented a cool
 feature (please talk to us before working on features to see whether they are

--- a/docs/4.3/i3-config-wizard.html
+++ b/docs/4.3/i3-config-wizard.html
@@ -70,7 +70,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.3/i3.html
+++ b/docs/4.3/i3.html
@@ -424,7 +424,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.3/i3.html
+++ b/docs/4.3/i3.html
@@ -197,7 +197,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.3/manpage.html
+++ b/docs/4.3/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.3/manpage.html
+++ b/docs/4.3/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.3/refcard.html
+++ b/docs/4.3/refcard.html
@@ -148,7 +148,7 @@
 	<table>
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.3/testsuite.html
+++ b/docs/4.3/testsuite.html
@@ -50,8 +50,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -60,7 +60,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.3/userguide.html
+++ b/docs/4.3/userguide.html
@@ -195,7 +195,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -218,7 +218,7 @@ appropriate hint and are opened in floating mode by default.</p></div>
 dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1678,7 +1678,7 @@ bindsym mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.7. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.7. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.3/userguide.html
+++ b/docs/4.3/userguide.html
@@ -199,8 +199,8 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
-<div class="paragraph"><p>To restart i3 inplace (and thus get into a clean state if there is a bug, or
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
+<div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>mod+Shift+r</tt>.</p></div>
 </div>
 <div class="sect2">
@@ -1787,7 +1787,7 @@ bindsym mod+u border none</tt></pre>
 <div class="sect2">
 <h3 id="stack-limit">6.11. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.3/userguide.html
+++ b/docs/4.3/userguide.html
@@ -167,7 +167,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">
@@ -514,7 +514,7 @@ floating_maximum_size -1 x -1</tt></pre>
 (anything wider than high) get horizontal orientation, rotated monitors
 (anything higher than wide) get vertical orientation.</p></div>
 <div class="paragraph"><p>With the <tt>default_orientation</tt> configuration directive, you can override that
-behaviour.</p></div>
+behavior.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
 <div class="content">
@@ -888,7 +888,7 @@ Leave fullscreen mode. This is the default.
 <div class="paragraph"><p>When being in a tabbed or stacked container, the first container will be
 focused when you use <tt>focus down</tt> on the last container&#8201;&#8212;&#8201;the focus wraps. If
 however there is another stacked/tabbed container in that direction, focus will
-be set on that container. This is the default behaviour so you can navigate to
+be set on that container. This is the default behavior so you can navigate to
 all your windows without having to use <tt>focus parent</tt>.</p></div>
 <div class="paragraph"><p>If you want the focus to <strong>always</strong> wrap and you are aware of using <tt>focus
 parent</tt> to switch to different containers, you can use the

--- a/docs/4.3/userguide.html
+++ b/docs/4.3/userguide.html
@@ -62,7 +62,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -88,7 +88,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>mod+J</tt> is left, <tt>mod+K</tt>
 is down, <tt>mod+L</tt> is up and <tt>mod+;</tt> is right. So, to switch between the

--- a/docs/4.3/userguide.html
+++ b/docs/4.3/userguide.html
@@ -193,7 +193,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.4/hacking-howto.html
+++ b/docs/4.4/hacking-howto.html
@@ -1486,7 +1486,7 @@ Forgetting to call <tt>floating_fix_coordinates(con, old_rect, new_rect)</tt> af
 <h2 id="_using_git_sending_patches">20. Using git / sending patches</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>For a short introduction into using git, see
-<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or, for more documentation, see
+<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or for more documentation, see
 <a href="http://git-scm.com/documentation">http://git-scm.com/documentation</a></p></div>
 <div class="paragraph"><p>Please talk to us before working on new features to see whether they will be
 accepted. There are a few things which we don’t want to see in i3, e.g. a

--- a/docs/4.4/i3-config-wizard.html
+++ b/docs/4.4/i3-config-wizard.html
@@ -70,7 +70,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.4/i3.html
+++ b/docs/4.4/i3.html
@@ -424,7 +424,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.4/i3.html
+++ b/docs/4.4/i3.html
@@ -197,7 +197,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.4/manpage.html
+++ b/docs/4.4/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.4/manpage.html
+++ b/docs/4.4/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.4/refcard.html
+++ b/docs/4.4/refcard.html
@@ -148,7 +148,7 @@
 	<table>
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.4/testsuite.html
+++ b/docs/4.4/testsuite.html
@@ -50,8 +50,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -60,7 +60,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.4/userguide.html
+++ b/docs/4.4/userguide.html
@@ -167,7 +167,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">
@@ -516,7 +516,7 @@ floating_maximum_size -1 x -1</tt></pre>
 (anything wider than high) get horizontal orientation, rotated monitors
 (anything higher than wide) get vertical orientation.</p></div>
 <div class="paragraph"><p>With the <tt>default_orientation</tt> configuration directive, you can override that
-behaviour.</p></div>
+behavior.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
 <div class="content">
@@ -909,7 +909,7 @@ Leave fullscreen mode.
 <div class="paragraph"><p>When being in a tabbed or stacked container, the first container will be
 focused when you use <tt>focus down</tt> on the last container&#8201;&#8212;&#8201;the focus wraps. If
 however there is another stacked/tabbed container in that direction, focus will
-be set on that container. This is the default behaviour so you can navigate to
+be set on that container. This is the default behavior so you can navigate to
 all your windows without having to use <tt>focus parent</tt>.</p></div>
 <div class="paragraph"><p>If you want the focus to <strong>always</strong> wrap and you are aware of using <tt>focus
 parent</tt> to switch to different containers, you can use the

--- a/docs/4.4/userguide.html
+++ b/docs/4.4/userguide.html
@@ -195,7 +195,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -218,7 +218,7 @@ appropriate hint and are opened in floating mode by default.</p></div>
 dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1734,7 +1734,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.4/userguide.html
+++ b/docs/4.4/userguide.html
@@ -62,7 +62,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -88,7 +88,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.4/userguide.html
+++ b/docs/4.4/userguide.html
@@ -199,8 +199,8 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
-<div class="paragraph"><p>To restart i3 inplace (and thus get into a clean state if there is a bug, or
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
+<div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
 <div class="sect2">
@@ -1843,7 +1843,7 @@ bindsym $mod+u border none</tt></pre>
 <div class="sect2">
 <h3 id="stack-limit">6.12. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.4/userguide.html
+++ b/docs/4.4/userguide.html
@@ -193,7 +193,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.5.1/hacking-howto.html
+++ b/docs/4.5.1/hacking-howto.html
@@ -1487,7 +1487,7 @@ Forgetting to call <tt>floating_fix_coordinates(con, old_rect, new_rect)</tt> af
 <h2 id="_using_git_sending_patches">20. Using git / sending patches</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>For a short introduction into using git, see
-<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or, for more documentation, see
+<a href="http://www.spheredev.org/wiki/Git_for_the_lazy">http://www.spheredev.org/wiki/Git_for_the_lazy</a> or for more documentation, see
 <a href="http://git-scm.com/documentation">http://git-scm.com/documentation</a></p></div>
 <div class="paragraph"><p>Please talk to us before working on new features to see whether they will be
 accepted. There are a few things which we don’t want to see in i3, e.g. a

--- a/docs/4.5.1/i3-config-wizard.html
+++ b/docs/4.5.1/i3-config-wizard.html
@@ -70,7 +70,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.5.1/i3.html
+++ b/docs/4.5.1/i3.html
@@ -424,7 +424,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.5.1/i3.html
+++ b/docs/4.5.1/i3.html
@@ -197,7 +197,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.5.1/manpage.html
+++ b/docs/4.5.1/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.5.1/manpage.html
+++ b/docs/4.5.1/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.5.1/refcard.html
+++ b/docs/4.5.1/refcard.html
@@ -148,7 +148,7 @@
 	<table>
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.5.1/testsuite.html
+++ b/docs/4.5.1/testsuite.html
@@ -50,8 +50,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -60,7 +60,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.5.1/userguide.html
+++ b/docs/4.5.1/userguide.html
@@ -167,7 +167,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">
@@ -516,7 +516,7 @@ floating_maximum_size -1 x -1</tt></pre>
 (anything wider than high) get horizontal orientation, rotated monitors
 (anything higher than wide) get vertical orientation.</p></div>
 <div class="paragraph"><p>With the <tt>default_orientation</tt> configuration directive, you can override that
-behaviour.</p></div>
+behavior.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
 <div class="content">
@@ -909,7 +909,7 @@ Leave fullscreen mode.
 <div class="paragraph"><p>When being in a tabbed or stacked container, the first container will be
 focused when you use <tt>focus down</tt> on the last container&#8201;&#8212;&#8201;the focus wraps. If
 however there is another stacked/tabbed container in that direction, focus will
-be set on that container. This is the default behaviour so you can navigate to
+be set on that container. This is the default behavior so you can navigate to
 all your windows without having to use <tt>focus parent</tt>.</p></div>
 <div class="paragraph"><p>If you want the focus to <strong>always</strong> wrap and you are aware of using <tt>focus
 parent</tt> to switch to different containers, you can use the

--- a/docs/4.5.1/userguide.html
+++ b/docs/4.5.1/userguide.html
@@ -195,7 +195,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -218,7 +218,7 @@ appropriate hint and are opened in floating mode by default.</p></div>
 dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1744,7 +1744,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.5.1/userguide.html
+++ b/docs/4.5.1/userguide.html
@@ -62,7 +62,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -88,7 +88,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.5.1/userguide.html
+++ b/docs/4.5.1/userguide.html
@@ -199,8 +199,8 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
-<div class="paragraph"><p>To restart i3 inplace (and thus get into a clean state if there is a bug, or
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
+<div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
 <div class="sect2">
@@ -1853,7 +1853,7 @@ bindsym $mod+u border none</tt></pre>
 <div class="sect2">
 <h3 id="stack-limit">6.12. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.5.1/userguide.html
+++ b/docs/4.5.1/userguide.html
@@ -193,7 +193,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.6/i3-config-wizard.html
+++ b/docs/4.6/i3-config-wizard.html
@@ -70,7 +70,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.6/i3.html
+++ b/docs/4.6/i3.html
@@ -424,7 +424,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.6/i3.html
+++ b/docs/4.6/i3.html
@@ -197,7 +197,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.6/manpage.html
+++ b/docs/4.6/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.6/manpage.html
+++ b/docs/4.6/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.6/refcard.html
+++ b/docs/4.6/refcard.html
@@ -148,7 +148,7 @@
 	<table>
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.6/testsuite.html
+++ b/docs/4.6/testsuite.html
@@ -50,8 +50,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -60,7 +60,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.6/userguide.html
+++ b/docs/4.6/userguide.html
@@ -199,7 +199,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -1934,7 +1934,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.14. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.6/userguide.html
+++ b/docs/4.6/userguide.html
@@ -167,7 +167,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">
@@ -517,7 +517,7 @@ floating_maximum_size -1 x -1</tt></pre>
 (anything wider than high) get horizontal orientation, rotated monitors
 (anything higher than wide) get vertical orientation.</p></div>
 <div class="paragraph"><p>With the <tt>default_orientation</tt> configuration directive, you can override that
-behaviour.</p></div>
+behavior.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
 <div class="content">
@@ -911,7 +911,7 @@ Leave fullscreen mode.
 <div class="paragraph"><p>When being in a tabbed or stacked container, the first container will be
 focused when you use <tt>focus down</tt> on the last container&#8201;&#8212;&#8201;the focus wraps. If
 however there is another stacked/tabbed container in that direction, focus will
-be set on that container. This is the default behaviour so you can navigate to
+be set on that container. This is the default behavior so you can navigate to
 all your windows without having to use <tt>focus parent</tt>.</p></div>
 <div class="paragraph"><p>If you want the focus to <strong>always</strong> wrap and you are aware of using <tt>focus
 parent</tt> to switch to different containers, you can use the

--- a/docs/4.6/userguide.html
+++ b/docs/4.6/userguide.html
@@ -195,7 +195,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -219,7 +219,7 @@ hint and are opened in floating mode by default.</p></div>
 dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1780,7 +1780,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.6/userguide.html
+++ b/docs/4.6/userguide.html
@@ -62,7 +62,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -88,7 +88,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.6/userguide.html
+++ b/docs/4.6/userguide.html
@@ -1908,7 +1908,7 @@ shmlog &lt;on|off|toggle&gt;</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/4.6/userguide.html
+++ b/docs/4.6/userguide.html
@@ -193,7 +193,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.7/i3-config-wizard.html
+++ b/docs/4.7/i3-config-wizard.html
@@ -70,7 +70,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.7/i3.html
+++ b/docs/4.7/i3.html
@@ -424,7 +424,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.7/i3.html
+++ b/docs/4.7/i3.html
@@ -197,7 +197,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.7/manpage.html
+++ b/docs/4.7/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.7/manpage.html
+++ b/docs/4.7/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.7/refcard.html
+++ b/docs/4.7/refcard.html
@@ -148,7 +148,7 @@
 	<table>
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" />+<kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.7/testsuite.html
+++ b/docs/4.7/testsuite.html
@@ -50,8 +50,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -60,7 +60,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.7/userguide.html
+++ b/docs/4.7/userguide.html
@@ -1939,7 +1939,7 @@ shmlog &lt;on|off|toggle&gt;</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/4.7/userguide.html
+++ b/docs/4.7/userguide.html
@@ -167,7 +167,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/4.7/userguide.html
+++ b/docs/4.7/userguide.html
@@ -62,7 +62,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -88,7 +88,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.7/userguide.html
+++ b/docs/4.7/userguide.html
@@ -199,7 +199,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -1965,7 +1965,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.14. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.7/userguide.html
+++ b/docs/4.7/userguide.html
@@ -195,7 +195,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -219,7 +219,7 @@ hint and are opened in floating mode by default.</p></div>
 dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1260,7 +1260,7 @@ you want to display a statusline-only bar containing additional information.</p>
 <div class="paragraph"><p>Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a <tt>mode</tt> definition, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+For an example of a <tt>mode</tt> definition, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>The default is to show the mode indicator.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
@@ -1811,7 +1811,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.7/userguide.html
+++ b/docs/4.7/userguide.html
@@ -193,7 +193,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.8/i3-config-wizard.html
+++ b/docs/4.8/i3-config-wizard.html
@@ -70,7 +70,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.8/i3.html
+++ b/docs/4.8/i3.html
@@ -424,7 +424,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.8/i3.html
+++ b/docs/4.8/i3.html
@@ -197,7 +197,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.8/manpage.html
+++ b/docs/4.8/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.8/manpage.html
+++ b/docs/4.8/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.8/refcard.html
+++ b/docs/4.8/refcard.html
@@ -173,7 +173,7 @@
                         <td>reload the configuration file
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.8/testsuite.html
+++ b/docs/4.8/testsuite.html
@@ -50,8 +50,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -60,7 +60,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.8/userguide.html
+++ b/docs/4.8/userguide.html
@@ -1992,7 +1992,7 @@ shmlog &lt;on|off|toggle&gt;</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/4.8/userguide.html
+++ b/docs/4.8/userguide.html
@@ -167,7 +167,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/4.8/userguide.html
+++ b/docs/4.8/userguide.html
@@ -199,7 +199,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -2018,7 +2018,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.14. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.8/userguide.html
+++ b/docs/4.8/userguide.html
@@ -62,7 +62,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -88,7 +88,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.8/userguide.html
+++ b/docs/4.8/userguide.html
@@ -195,7 +195,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -220,7 +220,7 @@ dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>. Another way to resize
 floating windows using the mouse is to right-click on the titlebar and drag.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1313,7 +1313,7 @@ workspaces to "1:I", "2:II", "3:III", "4:IV", &#8230;</p></div>
 <div class="paragraph"><p>Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a <tt>mode</tt> definition, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+For an example of a <tt>mode</tt> definition, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>The default is to show the mode indicator.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
@@ -1864,7 +1864,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.8/userguide.html
+++ b/docs/4.8/userguide.html
@@ -193,7 +193,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.9.1/i3-config-wizard.html
+++ b/docs/4.9.1/i3-config-wizard.html
@@ -71,7 +71,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.9.1/i3.html
+++ b/docs/4.9.1/i3.html
@@ -198,7 +198,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.9.1/i3.html
+++ b/docs/4.9.1/i3.html
@@ -425,7 +425,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.9.1/manpage.html
+++ b/docs/4.9.1/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.9.1/manpage.html
+++ b/docs/4.9.1/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.9.1/refcard.html
+++ b/docs/4.9.1/refcard.html
@@ -173,7 +173,7 @@
                         <td>reload the configuration file
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.9.1/testsuite.html
+++ b/docs/4.9.1/testsuite.html
@@ -51,8 +51,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -61,7 +61,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.9.1/userguide.html
+++ b/docs/4.9.1/userguide.html
@@ -2054,7 +2054,7 @@ shmlog &lt;on|off|toggle&gt;</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/4.9.1/userguide.html
+++ b/docs/4.9.1/userguide.html
@@ -200,7 +200,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -2080,7 +2080,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.14. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.9.1/userguide.html
+++ b/docs/4.9.1/userguide.html
@@ -194,7 +194,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/4.9.1/userguide.html
+++ b/docs/4.9.1/userguide.html
@@ -196,7 +196,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -222,7 +222,7 @@ dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>. Another way to resize
 floating windows using the mouse is to right-click on the titlebar and drag.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1368,7 +1368,7 @@ workspaces to "1:I", "2:II", "3:III", "4:IV", &#8230;</p></div>
 <div class="paragraph"><p>Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a <tt>mode</tt> definition, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+For an example of a <tt>mode</tt> definition, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>The default is to show the mode indicator.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
@@ -1926,7 +1926,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.9.1/userguide.html
+++ b/docs/4.9.1/userguide.html
@@ -168,7 +168,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/4.9.1/userguide.html
+++ b/docs/4.9.1/userguide.html
@@ -63,7 +63,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -89,7 +89,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.9/i3-config-wizard.html
+++ b/docs/4.9/i3-config-wizard.html
@@ -70,7 +70,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/4.9/i3.html
+++ b/docs/4.9/i3.html
@@ -424,7 +424,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/4.9/i3.html
+++ b/docs/4.9/i3.html
@@ -197,7 +197,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.9/manpage.html
+++ b/docs/4.9/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/4.9/manpage.html
+++ b/docs/4.9/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/4.9/refcard.html
+++ b/docs/4.9/refcard.html
@@ -173,7 +173,7 @@
                         <td>reload the configuration file
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>e</kbd>

--- a/docs/4.9/testsuite.html
+++ b/docs/4.9/testsuite.html
@@ -50,8 +50,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -60,7 +60,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/4.9/userguide.html
+++ b/docs/4.9/userguide.html
@@ -195,7 +195,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -221,7 +221,7 @@ dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>. Another way to resize
 floating windows using the mouse is to right-click on the titlebar and drag.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1367,7 +1367,7 @@ workspaces to "1:I", "2:II", "3:III", "4:IV", &#8230;</p></div>
 <div class="paragraph"><p>Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a <tt>mode</tt> definition, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+For an example of a <tt>mode</tt> definition, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>The default is to show the mode indicator.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
@@ -1925,7 +1925,7 @@ bindsym $mod+x move container to output VGA1</tt></pre>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.8. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.8. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/4.9/userguide.html
+++ b/docs/4.9/userguide.html
@@ -167,7 +167,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/4.9/userguide.html
+++ b/docs/4.9/userguide.html
@@ -2053,7 +2053,7 @@ shmlog &lt;on|off|toggle&gt;</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/4.9/userguide.html
+++ b/docs/4.9/userguide.html
@@ -62,7 +62,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -88,7 +88,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/4.9/userguide.html
+++ b/docs/4.9/userguide.html
@@ -199,7 +199,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -2079,7 +2079,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.14. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/docs/4.9/userguide.html
+++ b/docs/4.9/userguide.html
@@ -193,7 +193,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/i3-config-wizard.html
+++ b/docs/i3-config-wizard.html
@@ -71,7 +71,7 @@ exists. i3-config-wizard creates a keysym based i3 config file (based on
 <div class="paragraph"><p>The advantage of using keysyms is that the config file is easy to read,
 understand and modify. However, if we shipped with a keysym based default
 config file, the key positions would not be consistent across different
-keyboard layouts (take for example the homerow for movement). Therefore, we
+keyboard layouts (take for example the home row for movement). Therefore, we
 ship with a keycode based default config and let the wizard transform it
 according to your current keyboard layout.</p></div>
 </div>

--- a/docs/i3.html
+++ b/docs/i3.html
@@ -198,7 +198,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/i3.html
+++ b/docs/i3.html
@@ -425,7 +425,7 @@ bindsym Mod1+Shift+2 move workspace 2
 
 # reload the configuration file
 bindsym Mod1+Shift+c reload
-# restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+# restart i3 in place (preserves your layout/session, can be used to upgrade i3)
 bindsym Mod1+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym Mod1+Shift+e exit

--- a/docs/manpage.html
+++ b/docs/manpage.html
@@ -200,7 +200,7 @@ j/k/l/;
 </dt>
 <dd>
 <p>
-Direction keys (left, down, up, right). They are on your homerow (see the mark
+Direction keys (left, down, up, right). They are on your home row (see the mark
 on your "j" key). Alternatively, you can use the cursor keys.
 </p>
 </dd>

--- a/docs/manpage.html
+++ b/docs/manpage.html
@@ -381,7 +381,7 @@ bind Mod1+73 exec /home/michael/toggle_beamer.sh
 # Screen locking
 bind Mod1+68 exec /usr/bin/i3lock
 
-# Restart i3 inplace (Mod1+Shift+r)
+# Restart i3 in place (Mod1+Shift+r)
 bind Mod1+Shift+27 restart
 
 # Exit i3 (Mod1+Shift+e)

--- a/docs/refcard.html
+++ b/docs/refcard.html
@@ -173,7 +173,7 @@
                         <td>reload the configuration file
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>r</kbd>
-			<td>restart i3 inplace
+			<td>restart i3 in place
 
 		<tr>
 			<td><img class="i3mod" src="logo-30.png" alt="" /> + <kbd></kbd> + <kbd>e</kbd>

--- a/docs/testsuite.html
+++ b/docs/testsuite.html
@@ -51,8 +51,8 @@ interest for end users.</p></div>
 <div class="sectionbody">
 <div class="paragraph"><p>The i3 testsuite is a collection of files which contain testcases for various
 i3 features. Some of them test if a certain workflow works correctly (moving
-windows, focus behaviour, …). Others are regression tests and contain code
-which previously made i3 crash or lead to unexpected behaviour. They then check
+windows, focus behavior, …). Others are regression tests and contain code
+which previously made i3 crash or lead to unexpected behavior. They then check
 if i3 still runs (meaning it did not crash) and if it handled everything
 correctly.</p></div>
 <div class="paragraph"><p>The goal of having these tests is to automatically find problems and to
@@ -61,7 +61,7 @@ existing feature. After every modification of the i3 sourcecode, the developer
 should run the full testsuite. If one of the tests fails, the corresponding
 problem should be fixed (or, in some cases, the testcase has to be modified).
 For every bugreport, a testcase should be written to test the correct
-behaviour. Initially, it will fail, but after fixing the bug, it will pass.
+behavior. Initially, it will fail, but after fixing the bug, it will pass.
 This ensures (or increases the chance) that bugs which have been fixed once
 will never be found again.</p></div>
 <div class="paragraph"><p>Also, when implementing a new feature, a testcase might be a good way to be

--- a/docs/userguide.html
+++ b/docs/userguide.html
@@ -63,7 +63,7 @@ keybindings (click to see the full size image):</p></div>
 </a>
 </span></p></div>
 <div class="paragraph"><p>The red keys are the modifiers you need to press (by default), the blue keys
-are your homerow.</p></div>
+are your home row.</p></div>
 <div class="paragraph"><p>Note that when starting i3 without a config file, i3-config-wizard will offer
 you to create a config file in which the key positions (!) match what you see
 in the image above, regardless of the keyboard layout you are using. If you
@@ -95,7 +95,7 @@ existing window (rotated displays).</p></div>
 <img src="two_terminals.png" alt="Two terminals" />
 </span></p></div>
 <div class="paragraph"><p>To move the focus between the two terminals, you can use the direction keys
-which you may know from the editor <tt>vi</tt>. However, in i3, your homerow is used
+which you may know from the editor <tt>vi</tt>. However, in i3, your home row is used
 for these keys (in <tt>vi</tt>, the keys are shifted to the left by one for
 compatibility with most keyboard layouts). Therefore, <tt>$mod+J</tt> is left, <tt>$mod+K</tt>
 is down, <tt>$mod+L</tt> is up and <tt>$mod+;</tt> is right. So, to switch between the

--- a/docs/userguide.html
+++ b/docs/userguide.html
@@ -2435,7 +2435,7 @@ shmlog on|off|toggle</tt></pre>
 <pre><tt># Enable/disable logging
 bindsym $mod+x shmlog toggle
 
-# or, from a terminal:
+# or from a terminal:
 # increase the shared memory log buffer to 50 MiB
 i3-msg shmlog $((50*1024*1024))</tt></pre>
 </div></div>

--- a/docs/userguide.html
+++ b/docs/userguide.html
@@ -174,7 +174,7 @@ provide a menu, the escape key or a shortcut like <tt>Control+W</tt> to close), 
 can press <tt>$mod+Shift+q</tt> to kill a window. For applications which support
 the WM_DELETE protocol, this will correctly close the application (saving
 any modifications or doing other cleanup). If the application doesn’t support
-the WM_DELETE protocol your X server will kill the window and the behaviour
+the WM_DELETE protocol your X server will kill the window and the behavior
 depends on the application.</p></div>
 </div>
 <div class="sect2">

--- a/docs/userguide.html
+++ b/docs/userguide.html
@@ -200,7 +200,7 @@ it does not yet exist.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_resizing">2.8. Resizing</h3>
-<div class="paragraph"><p>The easiest way to resize a container is by using the mouse: Grab the border
+<div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
 <div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>

--- a/docs/userguide.html
+++ b/docs/userguide.html
@@ -202,7 +202,7 @@ it does not yet exist.</p></div>
 <h3 id="_resizing">2.8. Resizing</h3>
 <div class="paragraph"><p>By default, you can resize a container by using the mouse: Grab the border
 and move it to the wanted size.</p></div>
-<div class="paragraph"><p>See <a href="#resizingconfig">[resizingconfig]</a> for how to configure i3 to be able to resize
+<div class="paragraph"><p>See <a href="#resizing_containers">[resizing_containers]</a> for how to configure i3 to be able to resize
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
@@ -228,7 +228,7 @@ dragging the window’s titlebar with your mouse you can move the window
 around. By grabbing the borders and moving them you can resize the window. You
 can also do that by using the <a href="#floating_modifier">[floating_modifier]</a>. Another way to resize
 floating windows using the mouse is to right-click on the titlebar and drag.</p></div>
-<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+<div class="paragraph"><p>For resizing floating windows with your keyboard, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>Floating windows are always on top of tiling windows.</p></div>
 </div>
 </div>
@@ -1574,7 +1574,7 @@ workspaces to "1:I", "2:II", "3:III", "4:IV", &#8230;</p></div>
 <div class="paragraph"><p>Specifies whether the current binding mode indicator should be shown or not.
 This is useful if you want to hide the workspace buttons but still be able
 to see the current binding mode indicator.
-For an example of a <tt>mode</tt> definition, see <a href="#resizingconfig">[resizingconfig]</a>.</p></div>
+For an example of a <tt>mode</tt> definition, see <a href="#resizing_containers">[resizing_containers]</a>.</p></div>
 <div class="paragraph"><p>The default is to show the mode indicator.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
@@ -2241,7 +2241,7 @@ after the currently focused child within that container.</p></div>
 </div></div>
 </div>
 <div class="sect2">
-<h3 id="resizingconfig">6.11. Resizing containers/windows</h3>
+<h3 id="resizing_containers">6.11. Resizing containers/windows</h3>
 <div class="paragraph"><p>If you want to resize containers/windows using your keyboard, you can use the
 <tt>resize</tt> command:</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>

--- a/docs/userguide.html
+++ b/docs/userguide.html
@@ -206,7 +206,7 @@ and move it to the wanted size.</p></div>
 columns/rows with your keyboard.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_restarting_i3_inplace">2.9. Restarting i3 inplace</h3>
+<h3 id="_restarting_i3_inplace">2.9. Restarting i3 in place</h3>
 <div class="paragraph"><p>To restart i3 in place (and thus get into a clean state if there is a bug, or
 to upgrade to a newer version of i3) you can use <tt>$mod+Shift+r</tt>.</p></div>
 </div>
@@ -2461,7 +2461,7 @@ bindsym $mod+x debuglog toggle</tt></pre>
 <div class="sect2">
 <h3 id="_reloading_restarting_exiting">6.18. Reloading/Restarting/Exiting</h3>
 <div class="paragraph"><p>You can make i3 reload its configuration file with <tt>reload</tt>. You can also
-restart i3 inplace with the <tt>restart</tt> command to get it out of some weird state
+restart i3 in place with the <tt>restart</tt> command to get it out of some weird state
 (if that should ever happen) or to perform an upgrade without having to restart
 your X session. To exit i3 properly, you can use the <tt>exit</tt> command,
 however you don’t need to (simply killing your X session is fine as well).</p></div>

--- a/downloads/RELEASE-NOTES-4.0.1.txt
+++ b/downloads/RELEASE-NOTES-4.0.1.txt
@@ -74,7 +74,7 @@ now.
 
  • Floating now works for everything!
 
- • Your layout is now preserved when doing an inplace restart.
+ • Your layout is now preserved when doing an in place restart.
 
  • When you have an error in your config file, a new program called i3-nagbar
    will tell you so. It offers you two buttons: One to view the error in your

--- a/downloads/RELEASE-NOTES-4.0.txt
+++ b/downloads/RELEASE-NOTES-4.0.txt
@@ -64,7 +64,7 @@ now.
 
  • Floating now works for everything!
 
- • Your layout is now preserved when doing an inplace restart.
+ • Your layout is now preserved when doing an in place restart.
 
  • When you have an error in your config file, a new program called i3-nagbar
    will tell you so. It offers you two buttons: One to view the error in your


### PR DESCRIPTION
"The easiest way to resize a container is by using the mouse" in docs seemed a bit counter-intuitive to the usefulness of i3 with regards to using keyboard being essentially easier than using mouse for window management. In addition to revision for that, a few other revision suggestions committed here.