### PR TITLE
Fix broken link to i3status examples

### DIFF
--- a/i3status/manpage.html
+++ b/i3status/manpage.html
@@ -686,7 +686,7 @@ done</tt></pre>
 <div class="paragraph"><p>Put that in some script, say <tt>.bin/my_i3status.sh</tt> and execute that instead of i3status.</p></div>
 <div class="paragraph"><p>Note that if you want to use the JSON output format (with colors in i3bar), you
 need to use a slightly more complex wrapper script. There are examples in the
-contrib/ folder, see <a href="http://code.i3wm.org/i3status/tree/contrib">http://code.i3wm.org/i3status/tree/contrib</a></p></div>
+contrib/ folder, see <a href="https://github.com/i3/i3status/tree/master/contrib">https://github.com/i3/i3status/tree/master/contrib</a></p></div>
 </div>
 </div>
 <div class="sect1">


### PR DESCRIPTION
The current link tries to redirect to GitHub, but then returns 404

I did this quickly via GitHub UI, not sure why `#toc` forms part of the diff