### PR TITLE
Fixing pygments option deprecation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 # dummy comment to trigger a page build
 name: i3
 markdown: redcarpet
-pygments: true
+highlighter: pygments


### PR DESCRIPTION
Fixes:
Deprecation: The 'pygments' configuration option has been renamed to
'highlighter'. Please update your config file accordingly. The allowed
values are 'rouge', 'pygments' or null.

Tested with the same jekyll version github is using (3.1.1)