### PR TITLE
[WIP] Change recommended golang library to one that is maintained.

### DIFF
--- a/docs/ipc.html
+++ b/docs/ipc.html
@@ -1491,7 +1491,7 @@ Go
 <div class="ulist"><ul>
 <li>
 <p>
-<a href="https://github.com/proxypoke/i3ipc">https://github.com/proxypoke/i3ipc</a>
+<a href="https://github.com/mdirkse/i3ipc">https://github.com/mdirkse/i3ipc</a>
 </p>
 </li>
 </ul></div>


### PR DESCRIPTION
Hello i3 maintainers,
I recently started work on a [small golang utility for i3](https://github.com/mdirkse/i3wp) that's meant to replace a rather ugly bash script I wrote years ago. I wanted to use the IPC and the docs showed me the way to https://github.com/proxypoke/i3ipc. It seemed pretty complete until I noticed that the `version` call didn't return the `loaded_config_file_name` field. So I forked the project and created a pull request that added this field to the response.

While looking at the list of pull requests I noticed that one had been open since 2014 and [the most recent issue](https://github.com/proxypoke/i3ipc/issues/9) posed the very relevant question if the project was still maintained. As the last update is [from over 3 years ago](https://github.com/proxypoke/i3ipc/commit/de8f6bb6b583a14ca2164f0e1a8f9bea2c7e120e), I think we can safely say that the answer to that question is "no".

I propose that the i3 site changes its recommendation to [my fork](https://github.com/mdirkse/i3ipc) of the original library, one which I *will* maintain. The change shouldn't be made, however, before I do the following things:
* Enable travisci (and get the builds green)
* Fix issues reported by goreportcard.com :white_check_mark:
* Add travisci, godoc and goreportcard buttons :white_check_mark:
* Fix links to godoc (go.pkgdoc.org -> godoc.org) :white_check_mark:
* Update docs where necessary to remove references to the old project :white_check_mark:
* Update the library to reflect the latest version of the IPC data model