### PR TITLE
Fix keyring installation instructions

### DIFF
--- a/_docs/repositories
+++ b/_docs/repositories
@@ -35,7 +35,7 @@ release of i3. To use it, run the following commands:
 
 ---------------------------------------------------------------------------------
 $ /usr/lib/apt/apt-helper download-file http://debian.sur5r.net/i3/pool/main/s/sur5r-keyring/sur5r-keyring_2017.01.02_all.deb keyring.deb SHA256:4c3c6685b1181d83efe3a479c5ae38a2a44e23add55e16a328b8c8560bf05e5f
-# apt install ./keyring.deb
+# dpkg -i ./keyring.deb
 # echo "deb http://debian.sur5r.net/i3/ $(grep '^DISTRIB_CODENAME=' /etc/lsb-release | cut -f2 -d=) universe" >> /etc/apt/sources.list.d/sur5r-i3.list
 # apt update
 # apt install i3
@@ -53,7 +53,7 @@ minutes after every commit. To use it, run the following commands:
 
 ---------------------------------------------------------------------------------
 $ /usr/lib/apt/apt-helper download-file http://dl.bintray.com/i3/i3-autobuild-ubuntu/pool/main/i/i3-autobuild-keyring/i3-autobuild-keyring_2016.10.01_all.deb keyring.deb SHA256:460e8c7f67a6ae7c3996cc8a5915548fe2fee9637b1653353ec62b954978d844
-# apt install ./keyring.deb
+# dpkg -i ./keyring.deb
 # echo 'deb http://dl.bintray.com/i3/i3-autobuild-ubuntu xenial main' > /etc/apt/sources.list.d/i3-autobuild.list
 # apt update
 # apt install i3
@@ -69,7 +69,7 @@ minutes after every commit. To use it, run the following commands:
 
 ---------------------------------------------------------------------------------
 $ /usr/lib/apt/apt-helper download-file http://dl.bintray.com/i3/i3-autobuild/pool/main/i/i3-autobuild-keyring/i3-autobuild-keyring_2016.10.01_all.deb keyring.deb SHA256:460e8c7f67a6ae7c3996cc8a5915548fe2fee9637b1653353ec62b954978d844
-# apt install ./keyring.deb
+# dpkg -i ./keyring.deb
 # echo 'deb http://dl.bintray.com/i3/i3-autobuild sid main' > /etc/apt/sources.list.d/i3-autobuild.list
 # apt update
 # apt install i3

--- a/docs/repositories.html
+++ b/docs/repositories.html
@@ -88,7 +88,7 @@ release of i3. To use it, run the following commands:</p></div>
 <div class="listingblock">
 <div class="content">
 <pre><tt>$ /usr/lib/apt/apt-helper download-file http://debian.sur5r.net/i3/pool/main/s/sur5r-keyring/sur5r-keyring_2017.01.02_all.deb keyring.deb SHA256:4c3c6685b1181d83efe3a479c5ae38a2a44e23add55e16a328b8c8560bf05e5f
-# apt install ./keyring.deb
+# dpkg -i ./keyring.deb
 # echo "deb http://debian.sur5r.net/i3/ $(grep '^DISTRIB_CODENAME=' /etc/lsb-release | cut -f2 -d=) universe" &gt;&gt; /etc/apt/sources.list.d/sur5r-i3.list
 # apt update
 # apt install i3</tt></pre>
@@ -104,7 +104,7 @@ minutes after every commit. To use it, run the following commands:</p></div>
 <div class="listingblock">
 <div class="content">
 <pre><tt>$ /usr/lib/apt/apt-helper download-file http://dl.bintray.com/i3/i3-autobuild-ubuntu/pool/main/i/i3-autobuild-keyring/i3-autobuild-keyring_2016.10.01_all.deb keyring.deb SHA256:460e8c7f67a6ae7c3996cc8a5915548fe2fee9637b1653353ec62b954978d844
-# apt install ./keyring.deb
+# dpkg -i ./keyring.deb
 # echo 'deb http://dl.bintray.com/i3/i3-autobuild-ubuntu xenial main' &gt; /etc/apt/sources.list.d/i3-autobuild.list
 # apt update
 # apt install i3</tt></pre>
@@ -122,7 +122,7 @@ minutes after every commit. To use it, run the following commands:</p></div>
 <div class="listingblock">
 <div class="content">
 <pre><tt>$ /usr/lib/apt/apt-helper download-file http://dl.bintray.com/i3/i3-autobuild/pool/main/i/i3-autobuild-keyring/i3-autobuild-keyring_2016.10.01_all.deb keyring.deb SHA256:460e8c7f67a6ae7c3996cc8a5915548fe2fee9637b1653353ec62b954978d844
-# apt install ./keyring.deb
+# dpkg -i ./keyring.deb
 # echo 'deb http://dl.bintray.com/i3/i3-autobuild sid main' &gt; /etc/apt/sources.list.d/i3-autobuild.list
 # apt update
 # apt install i3</tt></pre>


### PR DESCRIPTION
'apt install' does not accept .deb files. Use 'dpkg -i' instead.