### PR TITLE
fix layouting bug in section 6.10

### DIFF
--- a/_docs/userguide
+++ b/_docs/userguide
@@ -2232,7 +2232,6 @@ bindsym $mod+x move container to output VGA1
 bindsym $mod+x move container to output primary
 --------------------------------------------------------
 
--------------------------------
 Note that you might not have a primary output configured yet. To do so, run:
 -------------------------
 xrandr --output <output> --primary


### PR DESCRIPTION
As visible on the i3wm.org-website, the layout in 6.10 is a bit weird.
The command "xrandr --output […]" is not displayed as a command (i.e.
terminal-style), but as regular text, the text accompanying it before
instead is displayed as a command.

This leads to other weird behaviour:
The following section "move window|container to mark <mark>" starts a
new chapter, which I don't think it should, and its accompanying
description is displayed a commands.

Since I don't know how to build this website, this fix might not even
fix it, and it is most certainly not tested. I apologize for that and
strongly second #39.