### PR TITLE
ipc: Add link to Crystal library

### DIFF
--- a/_docs/ipc
+++ b/_docs/ipc
@@ -879,6 +879,8 @@ C::
 	* https://github.com/acrisci/i3ipc-glib
 C++::
 	* https://github.com/drmgc/i3ipcpp
+Crystal::
+    * https://github.com/woodruffw/i3.cr
 Go::
 	* https://github.com/mdirkse/i3ipc-go
 JavaScript::


### PR DESCRIPTION
I wrote [i3.cr](https://github.com/woodruffw/i3.cr) a few weeks ago as a Crystal interface for i3. It supports all message types and subscriptions.