### PR TITLE
Fix userguide link

### DIFF
--- a/_docs/userguide
+++ b/_docs/userguide
@@ -2253,8 +2253,7 @@ See <<move_to_outputs>> for how to move a container/workspace to a different
 RandR output.
 
 [[move_to_outputs]]
-[[_moving_containers_workspaces_to_randr_outputs]]
-=== Moving containers/workspaces to RandR outputs
+=== [[_moving_containers_workspaces_to_randr_outputs]]Moving containers/workspaces to RandR outputs
 
 To move a container to another RandR output (addressed by names like +LVDS1+ or
 +VGA1+) or to a RandR output identified by a specific direction (like +left+,

--- a/docs/userguide.html
+++ b/docs/userguide.html
@@ -2542,7 +2542,7 @@ to "1: web", the above command will still switch to it.</p></div>
 RandR output.</p></div>
 </div>
 <div class="sect2">
-<h3 id="_moving_containers_workspaces_to_randr_outputs">6.10. Moving containers/workspaces to RandR outputs</h3>
+<h3 id="move_to_outputs">6.10. <a id="_moving_containers_workspaces_to_randr_outputs"></a>Moving containers/workspaces to RandR outputs</h3>
 <div class="paragraph"><p>To move a container to another RandR output (addressed by names like <tt>LVDS1</tt> or
 <tt>VGA1</tt>) or to a RandR output identified by a specific direction (like <tt>left</tt>,
 <tt>right</tt>, <tt>up</tt> or <tt>down</tt>), there are two commands:</p></div>


### PR DESCRIPTION
[[move_to_outputs]] doesn't work currently:
https://i3wm.org/docs/userguide.html#move_to_outputs
This does:
https://i3wm.org/docs/userguide.html#_moving_containers_workspaces_to_randr_outputs

This combines a 'BlockId Element' with an 'anchor'. Both should work
now.

See:
- https://github.com/i3/i3/issues/3225
- https://github.com/i3/i3/pull/3191