### PR TITLE
Make documentation responsive

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -161,7 +161,6 @@ img {
 }
 
 #content {
-    text-align: justify;
     max-width: 874px;
     padding-left: 1em;
     padding-right: 1em;

--- a/css/style.css
+++ b/css/style.css
@@ -426,12 +426,3 @@ html[xmlns] .clearfix {
     height: 1%;
 }
 
-.listingblock {
-    overflow-x: auto;
-}
-
-.listingblock .content {
-    width: available;
-    min-width: fit-content;
-}
-

--- a/css/style.css
+++ b/css/style.css
@@ -30,7 +30,7 @@ a:hover {
 }
 
 #main {
-    width: 912px;
+    max-width: 912px;
     margin: 0 auto;
     padding: 0;
 }
@@ -70,7 +70,7 @@ a:hover {
 
 h1#title {
     height: 146px;
-    width: 458px;
+    max-width: 458px;
     float: left;
     margin: 0;
     background-image: url(../img/logo.svg);
@@ -85,6 +85,7 @@ h1#title {
 }
 
 img {
+    max-width: 100%;
     border: 0;
 }
 
@@ -101,7 +102,7 @@ img {
     margin-right: 0.9em;
     margin-top: 1em;
 
-    width: 840px;
+    max-width: 840px;
     color: #666;
     font-size: 1.6em;
     letter-spacing: -1px;
@@ -161,7 +162,7 @@ img {
 
 #content {
     text-align: justify;
-    width: 874px;
+    max-width: 874px;
     padding-left: 1em;
     padding-right: 1em;
     line-height: 150%;
@@ -169,9 +170,6 @@ img {
     font-size: 1.2em;
 }
 
-#content p {
-    padding-right: 2em;
-}
 #content li {
     margin-bottom: 1em;
     padding-right: 2em;
@@ -247,7 +245,7 @@ img {
 }
 
 .screenshots, .screencasts, .video {
-    width: 100%;
+    max-width: 100%;
 }
 
 .screenshots .shot {
@@ -258,7 +256,8 @@ img {
     margin-bottom: 1em;
     text-align: center;
     color: #c0c0c0;
-    width: 240px;
+    width: 100%;
+    max-width: 240px;
     min-height: 125px;
 }
 
@@ -279,7 +278,7 @@ img {
     position: fixed;
     left: 50%;
     top: 50%;
-    width: 58px;
+    max-width: 58px;
     height: 60px;
     background-color: black;
     background-image: url('/img/loading.gif');
@@ -293,7 +292,7 @@ img {
     position: fixed;
     top: 0;
     left: 0;
-    width: 100%;
+    max-width: 100%;
     height: 100%;
     display: none;
 }
@@ -336,7 +335,7 @@ img {
     left: 64px;
     bottom: 0;
     background-color: #333;
-    width: 100%;
+    max-width: 100%;
     padding-top: 1em;
     padding-bottom: 1em;
     padding-left: 2em;
@@ -427,3 +426,13 @@ html[xmlns] .clearfix {
 * html .clearfix {
     height: 1%;
 }
+
+.listingblock {
+    overflow-x: auto;
+}
+
+.listingblock .content {
+    width: available;
+    min-width: fit-content;
+}
+

--- a/css/xhtml11.css
+++ b/css/xhtml11.css
@@ -19,6 +19,15 @@ tt {
   color: #3ec2ff;
 }
 
+div.listingblock {
+  overflow-x: auto;
+}
+
+div.listingblock .content {
+  width: available;
+  min-width: fit-content;
+}
+
 div.listingblock tt {
   color: #fff;
 }


### PR DESCRIPTION
I am using the documentation site on a small laptop screen which is horizontally split and the documentation overflowed horizontally.

I've changed most of the `width` specifiers to `max-width` which is pretty much everything needed to make it responsive.

I've also removed `text-align: justified;` as this can make text less readable, especially for people with dyslexia.