### PR TITLE
Fix swapping workspaces script colon issue

### DIFF
--- a/docs/user-contributed/swapping-workspaces.html
+++ b/docs/user-contributed/swapping-workspaces.html
@@ -23,17 +23,12 @@ workspace to the other monitor.
 <pre><tt>#!/usr/bin/env bash
 # requires jq
 
-DISPLAY_CONFIG=($(i3-msg -t get_outputs | jq -r '.[]|"\(.name):\(.current_workspace)"'))
-
-for ROW in "${DISPLAY_CONFIG[@]}"
-do
-    IFS=':'
-    read -ra CONFIG <<< "${ROW}"
-    if [ "${CONFIG[0]}" != "null" ] && [ "${CONFIG[1]}" != "null" ]; then
-        echo "moving ${CONFIG[1]} right..."
-        i3-msg workspace "${CONFIG[1]}"
-        i3-msg move workspace to output right	
-    fi
+IFS=:
+i3-msg -t get_outputs | jq -r '.[]|"\(.name):\(.current_workspace)"' | grep -v '^null:null$' | \
+while read -r name current_workspace; do
+    echo "moving ${current_workspace} right..."
+    i3-msg workspace "${current_workspace}"
+    i3-msg move workspace to output right   
 done</tt></pre>
 
 <p>


### PR DESCRIPTION
From https://www.reddit.com/r/i3wm/comments/9o218m/found_a_bug_in_swapping_workspaces/e7rtorl/

Using `read -a` means a workspace name with a colon breaks (because colon is used as separator in `jq`). A cleaner way is to use `read` into separate variables, which will write the entire tail in the last variable. Also simplifies the if-statement with a `grep` invocation.