### PR TITLE
Change copyright notice to show 2009-present

### DIFF
--- a/_docs/conf/i3html.conf
+++ b/_docs/conf/i3html.conf
@@ -651,7 +651,9 @@ endif::doctype-manpage[]
 </div>
 {disable-javascript%<div id="footnotes"><hr /></div>}
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -71,11 +71,10 @@ else window.onload = loadjs;
 	<br style="clear: both">
 	    {{ content }}
         </div>
-
-	<div id="footer" lang="de">
-	    © 2009 Michael Stapelberg,
-	    <a href="/impress.html">Impressum</a>,
-	    <a href="https://github.com/i3/i3.github.io">Source</a>
-	</div>
+    <div id="footer" lang="de">
+        © 2009-present Michael Stapelberg,
+        <a href="/impress.html">Impressum</a>,
+        <a href="https://github.com/i3/i3.github.io">Source</a>
+    </div>
     </body>
 </html>

--- a/docs/buildbot.html
+++ b/docs/buildbot.html
@@ -1113,7 +1113,9 @@ c['db'] = {
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/debugging-release-version.html
+++ b/docs/debugging-release-version.html
@@ -170,7 +170,9 @@ length limitations) or flood kicks.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/debugging.html
+++ b/docs/debugging.html
@@ -249,7 +249,9 @@ in your bug report.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/gsoc2013-ideas.html
+++ b/docs/gsoc2013-ideas.html
@@ -194,7 +194,9 @@ How X11 works
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/hacking-howto.html
+++ b/docs/hacking-howto.html
@@ -1673,7 +1673,9 @@ used for this.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/i3-config-wizard.html
+++ b/docs/i3-config-wizard.html
@@ -91,7 +91,9 @@ according to your current keyboard layout.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/i3-migrate-config-to-v4.html
+++ b/docs/i3-migrate-config-to-v4.html
@@ -82,7 +82,9 @@ longer be supported.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/i3-msg.html
+++ b/docs/i3-msg.html
@@ -95,7 +95,9 @@ to connect to i3.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/i3-nagbar.html
+++ b/docs/i3-nagbar.html
@@ -85,7 +85,9 @@ after modifying the configuration file.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/i3.html
+++ b/docs/i3.html
@@ -524,7 +524,9 @@ i3-migrate-config-to-v4(1)</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/i3bar-protocol.html
+++ b/docs/i3bar-protocol.html
@@ -456,7 +456,9 @@ modifiers
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/i3status.html
+++ b/docs/i3status.html
@@ -663,7 +663,9 @@ after changing the system volume, for example.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/ipc.html
+++ b/docs/ipc.html
@@ -1888,7 +1888,9 @@ From here on out, send/receive all messages using the detected byte order.
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/layout-saving.html
+++ b/docs/layout-saving.html
@@ -331,7 +331,9 @@ that value:</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/manpage.html
+++ b/docs/manpage.html
@@ -522,7 +522,9 @@ and the "how to hack" guide. If you are building from source, run:
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/multi-monitor.html
+++ b/docs/multi-monitor.html
@@ -108,7 +108,9 @@ Guide.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/repositories.html
+++ b/docs/repositories.html
@@ -150,7 +150,9 @@ Pin-Priority: 1001</tt></pre>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/testsuite.html
+++ b/docs/testsuite.html
@@ -726,7 +726,9 @@ implement, it wastes CPU time and is considerably uglier than this solution
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/tree-migrating.html
+++ b/docs/tree-migrating.html
@@ -263,7 +263,9 @@ implemented.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/tshirts.html
+++ b/docs/tshirts.html
@@ -208,7 +208,9 @@ on pickup
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/userguide.html
+++ b/docs/userguide.html
@@ -3132,7 +3132,9 @@ software needs to do this job (that is, open a window on each screen).</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/docs/wsbar.html
+++ b/docs/wsbar.html
@@ -136,7 +136,9 @@ bar which you will see should look exactly like the internal bar of i3.</p></div
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>

--- a/i3status/manpage.html
+++ b/i3status/manpage.html
@@ -789,7 +789,9 @@ after changing the system volume, for example.</p></div>
 </div>
 <div id="footnotes"><hr /></div>
 <div id="footer" lang="de">
-© 2009-2011 Michael Stapelberg, <a href="/impress.html">Impressum</a>
+    © 2009-present Michael Stapelberg,
+    <a href="/impress.html">Impressum</a>,
+    <a href="https://github.com/i3/i3.github.io">Source</a>
 </div>
 </body>
 </html>


### PR DESCRIPTION
A bit late but better late than never right? I only changed the most recent doc footers, not the old versions. I was not able to make it dynamic as the docs don't seem to be jekyll generated at all. I presume this is so that they can be downloaded/crawled or it's simply because they haven't been converted to jekyll dynamic docs yet. I will continue looking into it though and see if they can be made into jekyll docs for the sake of making them dynamic and reducing the massive amount of code duplication. For now though, 2009-present is good enough. Closes #59 