### PR TITLE
add install instructions to i3lock page

### DIFF
--- a/i3lock/index.html
+++ b/i3lock/index.html
@@ -35,8 +35,10 @@ title: i3lock
 <h2>Install</h2>
 
 <p>
-  Many operating system i3 packages come with i3lock bundled (see
-  <a href="/downloads/">Downloads</a>), but it can be installed manually, e.g.:
+  Many distributions include i3lock as a (potentially optional) dependency
+  of the i3 package (see <a href="/downloads/">Downloads</a>). You can also
+  look for the specific package in your distribution, e.g. on Debian and
+  Debian-based distributions:
 </p>
 
 <pre>

--- a/i3lock/index.html
+++ b/i3lock/index.html
@@ -32,6 +32,16 @@ title: i3lock
   </li>
 </ul>
 
+<h2>Install</h2>
+
+<p>
+  Many operating system i3 packages come with i3lock bundled (see
+  <a href="/downloads/">Downloads</a>), but it can be installed manually, e.g.:
+</p>
+
+<pre>
+sudo apt-get install i3lock
+</pre>
 
 <h2>Releases</h2>
 


### PR DESCRIPTION
Add i3lock install instructions. As discussed in https://github.com/i3/i3lock/pull/223