### PR TITLE
docs/repositories.html | Update URL for debian.sur5r.net to point to https://

### DIFF
--- a/docs/repositories.html
+++ b/docs/repositories.html
@@ -87,9 +87,9 @@ If you want the latest i3 development version
 release of i3. To use it, run the following commands:</p></div>
 <div class="listingblock">
 <div class="content">
-<pre><tt>$ /usr/lib/apt/apt-helper download-file http://debian.sur5r.net/i3/pool/main/s/sur5r-keyring/sur5r-keyring_2019.02.01_all.deb keyring.deb SHA256:176af52de1a976f103f9809920d80d02411ac5e763f695327de9fa6aff23f416
+<pre><tt>$ /usr/lib/apt/apt-helper download-file https://debian.sur5r.net/i3/pool/main/s/sur5r-keyring/sur5r-keyring_2019.02.01_all.deb keyring.deb SHA256:176af52de1a976f103f9809920d80d02411ac5e763f695327de9fa6aff23f416
 # dpkg -i ./keyring.deb
-# echo "deb http://debian.sur5r.net/i3/ $(grep '^DISTRIB_CODENAME=' /etc/lsb-release | cut -f2 -d=) universe" &gt;&gt; /etc/apt/sources.list.d/sur5r-i3.list
+# echo "deb https://debian.sur5r.net/i3/ $(grep '^DISTRIB_CODENAME=' /etc/lsb-release | cut -f2 -d=) universe" &gt;&gt; /etc/apt/sources.list.d/sur5r-i3.list
 # apt update
 # apt install i3</tt></pre>
 </div></div>


### PR DESCRIPTION
I found the docs were a little outdated, per https://github.com/i3/i3/issues/3781

This PR will correct the issue with sur5r.net's URL