### PR TITLE
added missing get_tree node field: "marks"

### DIFF
--- a/_docs/ipc
+++ b/_docs/ipc
@@ -350,6 +350,8 @@ urgent (bool)::
 	workspace) has the urgency hint set, directly or indirectly. All parent
 	containers up until the workspace container will be marked urgent if they
 	have at least one urgent child.
+marks (array of string)::
+    Marks assigned to this node.
 focused (bool)::
 	Whether this container is currently focused.
 focus (array of integer)::


### PR DESCRIPTION
There is node's `marks` field not documented in get_tree output:

```
$ i3-msg -t get_tree| jq '.' | grep '"marks"' -B8 -A2
                  "nodes": [
                    {
                      "id": 94075649667232,
                      "type": "con",
                      "orientation": "none",
                      "scratchpad_state": "none",
                      "percent": 1,
                      "urgent": false,
                      "marks": [
                        "scratch2"
                      ],
--
                  "nodes": [
                    {
                      "id": 94075648820464,
                      "type": "con",
                      "orientation": "none",
                      "scratchpad_state": "none",
                      "percent": 1,
                      "urgent": false,
                      "marks": [
                        "scratch1"
                      ],
```