### PR TITLE
Use 'stable' branch name in downloads page

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -499,16 +499,16 @@ Please verify all releases before using them.
 </pre>
 
 <p>
-  The 'master' branch is the current stable version plus bugfixes.<br>
+  The 'stable' branch is the current stable version plus bugfixes.<br>
   The 'next' branch is the next version, yet to be released. Use <tt>git
-  checkout master</tt> to switch to the 'master' branch.
+  checkout stable</tt> to switch to the 'stable' branch.
 </p>
 
 <p>
   If you prefer to download a tarball, or if you cannot use git for whatever reason,
-  you may download the current master branch from
-  <a href="https://github.com/i3/i3/archive/master.tar.gz">
-    https://github.com/i3/i3/archive/master.tar.gz
+  you may download the current stable branch from
+  <a href="https://github.com/i3/i3/archive/stable.tar.gz">
+    https://github.com/i3/i3/archive/stable.tar.gz
   </a>.
 </p>
 


### PR DESCRIPTION
Update downloads page to reflect current branch name

Fixes #89 

Signed-off-by: Rob Gill <rrobgill@protonmail.com>