### PR TITLE
Fix broken py3status links

### DIFF
--- a/docs/user-contributed/py3status.html
+++ b/docs/user-contributed/py3status.html
@@ -47,7 +47,7 @@ This should be said that py3status is much more than just a wrapper script.
     <a href="https://py3status.readthedocs.io/en/latest">Read the Docs</a>
 </li>
 <li>
-    <a href="https://github.com/ultrabug/py3status/tree/master/doc">Github</a>
+    <a href="https://github.com/ultrabug/py3status/tree/master/docs">Github</a>
 </li>
 </ul>
 
@@ -85,7 +85,7 @@ bar {
 </tt></pre>
 
 <p>Learn more about how to configure py3status on the
-<a href="https://py3status.readthedocs.io/en/latest/configuration.html">
+<a href="https://py3status.readthedocs.io/en/latest/user-guide/configuration">
 configuration documentation</a>
 </p>
 
@@ -93,7 +93,7 @@ configuration documentation</a>
 
 <p>Like i3status, py3status comes with modules (but a lot of them!).</p>
 <p>Learn more about the modules provided by py3status on the
-<a href="https://py3status.readthedocs.io/en/latest/modules.html">modules
+<a href="https://py3status.readthedocs.io/en/latest/user-guide/modules">modules
 documentation</a>
 </p>
 
@@ -246,7 +246,7 @@ modules, on the functions and parameters, on making new modules, and many more.
 </ul>
 
 <p>Learn how to
-<a href="https://py3status.readthedocs.io/en/latest/writing_modules.html">write
+<a href="https://py3status.readthedocs.io/en/latest/dev-guide/writing-modules/">write
 (and contribute please!) your own modules!</a></p>
 
 


### PR DESCRIPTION
Hi

Noticed some broken links when working through https://i3wm.org/docs/user-contributed/py3status.html.

Couldn't find the user contributed articles in `_docs` as mentioned in the contributing section. If I should update them somewhere else please let me know.

PS. A big thank you to all the maintainers of this awesome project

Alex
