### PR TITLE
note that commas are needed between containers

### DIFF
--- a/docs/layout-saving.html
+++ b/docs/layout-saving.html
@@ -300,7 +300,7 @@ container:</p></div>
     "type": "con",
     "nodes": [
 
-        // the dumped workspace layout goes here
+        // the dumped workspace layout goes here (add commas between containers)
 
     ]
 }</tt></pre>


### PR DESCRIPTION
The dumped workspace layout contains multiple JSON texts without commas between them. Once nested inside another block, commas are needed to get a valid parse.  Point that out so users won't be wondering why their layout isn't being applied.