### PR TITLE
Update RELEASE-NOTES-4.21.txt

### DIFF
--- a/downloads/RELEASE-NOTES-4.21.txt
+++ b/downloads/RELEASE-NOTES-4.21.txt
@@ -71,4 +71,4 @@ Josh Soref, Kjetil Torgrim Homme, lycurgus, mariano, Michael Forster, Orestis
 Floros, paperluigis, Peder Stray, rvalieris, sergio, Tony Crisci, takelley1, Uli
 Schlachter, viri, zhiv-git, zhrvn
 
--- Michael Stapelberg, 2021-10-19
+-- Michael Stapelberg, 2022-09-21


### PR DESCRIPTION
I doubt, that you wrote this 2021-10-19, when the release was on 2022-09-21.

Yes, this is nit-picking. But somebody might get confused. :-)