### PR TITLE
Fix "default binding" mistake in userguide

### DIFF
--- a/_docs/userguide
+++ b/_docs/userguide
@@ -317,7 +317,7 @@ single workspace on which you open three terminal windows. All these terminal
 windows are directly attached to one node inside i3’s layout tree, the
 workspace node. By default, the workspace node’s orientation is +horizontal+.
 
-Now you move one of these terminals down (+$mod+Shift+j+ by default). The
+Now you move one of these terminals down (+$mod+Shift+k+ by default). The
 workspace node’s orientation will be changed to +vertical+. The terminal window
 you moved down is directly attached to the workspace and appears on the bottom
 of the screen. A new (horizontal) container was created to accommodate the


### PR DESCRIPTION
Default binding to move window down is $mod+Shift+k, not $mod+Shift+j. Proof: https://github.com/i3/i3/blob/next/etc/config#L45

Related PR in i3 repo: https://github.com/i3/i3/pull/5390