### PR TITLE
Update debian.sur5r.net keyring and repository instructions

### DIFF
--- a/_docs/repositories
+++ b/_docs/repositories
@@ -34,9 +34,9 @@ This Ubuntu repository is provided by sur5r and contains the latest stable
 release of i3. To use it, run the following commands:
 
 ---------------------------------------------------------------------------------
-$ /usr/lib/apt/apt-helper download-file https://debian.sur5r.net/i3/pool/main/s/sur5r-keyring/sur5r-keyring_2024.03.04_all.deb keyring.deb SHA256:f9bb4340b5ce0ded29b7e014ee9ce788006e9bbfe31e96c09b2118ab91fca734
+$ /usr/lib/apt/apt-helper download-file https://debian.sur5r.net/i3/pool/main/s/sur5r-keyring/sur5r-keyring_2025.03.09_all.deb keyring.deb SHA256:2c2601e6053d5c68c2c60bcd088fa9797acec5f285151d46de9c830aaba6173c
 $ sudo apt install ./keyring.deb
-$ echo "deb http://debian.sur5r.net/i3/ $(grep '^DISTRIB_CODENAME=' /etc/lsb-release | cut -f2 -d=) universe" | sudo tee /etc/apt/sources.list.d/sur5r-i3.list
+$ echo "deb [signed-by=/usr/share/keyrings/sur5r-keyring.gpg] http://debian.sur5r.net/i3/ $(grep '^VERSION_CODENAME=' /etc/os-release | cut -f2 -d=) universe" | sudo tee /etc/apt/sources.list.d/sur5r-i3.list
 $ sudo apt update
 $ sudo apt install i3
 ---------------------------------------------------------------------------------

--- a/docs/repositories.html
+++ b/docs/repositories.html
@@ -90,9 +90,9 @@ If you want the latest i3 development version
 release of i3. To use it, run the following commands:</p></div>
 <div class="listingblock">
 <div class="content">
-<pre><tt>$ /usr/lib/apt/apt-helper download-file https://debian.sur5r.net/i3/pool/main/s/sur5r-keyring/sur5r-keyring_2024.03.04_all.deb keyring.deb SHA256:f9bb4340b5ce0ded29b7e014ee9ce788006e9bbfe31e96c09b2118ab91fca734
+<pre><tt>$ /usr/lib/apt/apt-helper download-file https://debian.sur5r.net/i3/pool/main/s/sur5r-keyring/sur5r-keyring_2025.03.09_all.deb keyring.deb SHA256:2c2601e6053d5c68c2c60bcd088fa9797acec5f285151d46de9c830aaba6173c
 $ sudo apt install ./keyring.deb
-$ echo "deb http://debian.sur5r.net/i3/ $(grep '^DISTRIB_CODENAME=' /etc/lsb-release | cut -f2 -d=) universe" | sudo tee /etc/apt/sources.list.d/sur5r-i3.list
+$ echo "deb [signed-by=/usr/share/keyrings/sur5r-keyring.gpg] http://debian.sur5r.net/i3/ $(grep '^VERSION_CODENAME=' /etc/os-release | cut -f2 -d=) universe" | sudo tee /etc/apt/sources.list.d/sur5r-i3.list
 $ sudo apt update
 $ sudo apt install i3</tt></pre>
 </div></div>


### PR DESCRIPTION
Also, since /etc/lsb-release will no longer be around in the future, so switch to /etc/os-release instead.