### PR TITLE
Fix typos via codespell

### DIFF
--- a/_docs/gsoc2013-ideas
+++ b/_docs/gsoc2013-ideas
@@ -67,7 +67,7 @@ We often receive bug reports which are specific to certain toolkits and/or
 applications. For example, people are reporting problems with the IntelliJ IDE,
 Java applications in general, VMware or Half-Life (via Steam).
 
-Most often, these problems are caused by i3 doing things slighty differently
+Most often, these problems are caused by i3 doing things slightly differently
 than other window managers and can be solved by observing and comparing what
 others do and what i3 does.
 

--- a/_docs/i3status.man
+++ b/_docs/i3status.man
@@ -23,7 +23,7 @@ configuration files in the following order:
 4. /etc/i3status.conf
 
 -h --help::
-Print the verison and a minimal syntax.
+Print the version and a minimal syntax.
 
 -v --version::
 Print the version and any build configuration.

--- a/_docs/ipc
+++ b/_docs/ipc
@@ -24,7 +24,7 @@ will print the path to the standard output (plus a newline) or by reading the
 +I3SOCK+ environmental variable.
 
 All i3 utilities, like +i3-msg+ and +i3-input+ will determine the path of the
-IPC socket frome the +I3SOCK+ environmental variable if it is set or the
+IPC socket from the +I3SOCK+ environmental variable if it is set or the
 +I3_SOCKET_PATH+ X11 property, stored on the X11 root window.
 
 [WARNING]

--- a/_docs/userguide
+++ b/_docs/userguide
@@ -1427,7 +1427,7 @@ The default is +modifier+.
 Since i3 4.24, you can configure a modifier key which, when pressed, will swap
 instead of moving containers when dropping directly onto another container.
 Defaults to +Shift+. Note that you have to be pressing both the floating
-modifer and the swap modifier before the drag is initiated.
+modifier and the swap modifier before the drag is initiated.
 
 *Syntax*:
 --------------------------------

--- a/css/style.css
+++ b/css/style.css
@@ -137,7 +137,7 @@ footer {
 /*
  * Styling for each major sub-section of the site
  *  - home
- *  - downloads/distrbutions
+ *  - downloads/distributions
  *  - docs
  *  - screenshots
  */

--- a/css/xhtml11.css
+++ b/css/xhtml11.css
@@ -247,7 +247,7 @@ td > div.verse {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/docs/gsoc2013-ideas.html
+++ b/docs/gsoc2013-ideas.html
@@ -156,7 +156,7 @@ How to implement an entirely new feature into an existing codebase
 <div class="paragraph"><p>We often receive bug reports which are specific to certain toolkits and/or
 applications. For example, people are reporting problems with the IntelliJ IDE,
 Java applications in general, VMware or Half-Life (via Steam).</p></div>
-<div class="paragraph"><p>Most often, these problems are caused by i3 doing things slighty differently
+<div class="paragraph"><p>Most often, these problems are caused by i3 doing things slightly differently
 than other window managers and can be solved by observing and comparing what
 others do and what i3 does.</p></div>
 <div class="paragraph"><p>Fixing compatibility problems is a huge gain for the users of said

--- a/docs/i3status.html
+++ b/docs/i3status.html
@@ -94,7 +94,7 @@ configuration files in the following order:
 </dt>
 <dd>
 <p>
-Print the verison and a minimal syntax.
+Print the version and a minimal syntax.
 </p>
 </dd>
 <dt class="hdlist1">

--- a/docs/ipc.html
+++ b/docs/ipc.html
@@ -78,7 +78,7 @@ The <tt>I3SOCK</tt> environmental variable if it is set
 will print the path to the standard output (plus a newline) or by reading the
 <tt>I3SOCK</tt> environmental variable.</p></div>
 <div class="paragraph"><p>All i3 utilities, like <tt>i3-msg</tt> and <tt>i3-input</tt> will determine the path of the
-IPC socket frome the <tt>I3SOCK</tt> environmental variable if it is set or the
+IPC socket from the <tt>I3SOCK</tt> environmental variable if it is set or the
 <tt>I3_SOCKET_PATH</tt> X11 property, stored on the X11 root window.</p></div>
 <div class="admonitionblock">
 <table><tr>

--- a/docs/tree-migrating.html
+++ b/docs/tree-migrating.html
@@ -42,7 +42,7 @@ window.onload = function(){asciidoc.footnotes(); asciidoc.toc(2);}
 <div class="sectionbody">
 <div class="paragraph"><p>The tree branch (referring to a branch of i3 in the git repository) is the new
 version of i3. Due to the very deep changes and heavy refactoring of the source
-source, we decided to develop it in a seperate branch (instead of using the
+source, we decided to develop it in a separate branch (instead of using the
 next/master-branch system like before).</p></div>
 </div>
 </div>
@@ -84,7 +84,7 @@ So, make sure you use/customize the provided <tt>i3.config</tt> file.</p></div>
 <div class="paragraph"><p>The most important change and reason for the name is that i3 stores all
 information about the X11 outputs, workspaces and layout of the windows on them
 in a tree. The root node is the X11 root window, followed by the X11 outputs,
-then workspaces and finally the windows themselve. In previous versions of i3
+then workspaces and finally the windows themselves. In previous versions of i3
 we had multiple lists (of outputs, workspaces) and a table for each workspace.
 That approach turned out to be complicated to use (snapping), understand and
 implement.</p></div>
@@ -168,7 +168,7 @@ windows will be opened to the right of the <tt>Vertical Split Container</tt>:</p
 <div class="sect1">
 <h2 id="_commands">5. Commands</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>The authoritive reference for commands is <tt>src/cmdparse.y</tt>. You can also find
+<div class="paragraph"><p>The authoritative reference for commands is <tt>src/cmdparse.y</tt>. You can also find
 most commands in <tt>i3.config</tt>. Here comes a short overview over the important
 commands:</p></div>
 <div class="sect2">

--- a/docs/user-contributed/conky-i3bar.html
+++ b/docs/user-contributed/conky-i3bar.html
@@ -110,7 +110,7 @@ Now we have to write a <tt>~/.conkyrc</tt> file in order to obtain the desired s
 ],</tt></pre>
 
 <p>
-Here's a sample conkyrc that updates every 2 seconds. Just to make things a litte bit more exciting 
+Here's a sample conkyrc that updates every 2 seconds. Just to make things a little bit more exciting
 we put a condition in the script in order to write the occupied RAM in red if the amount is more than 90%:
 </p>
 

--- a/docs/user-contributed/luastatus-i3bar.html
+++ b/docs/user-contributed/luastatus-i3bar.html
@@ -137,7 +137,7 @@ widget = luastatus.require_plugin('cpu-usage-linux').widget{
 field of the global <code>widget</code> table. Its value might be either a function, or a string.
 
 <p>If the <code>event</code> field of the global <code>widget</code> table is a <b>function</b>, then it is invoked
-each time the i3 barlib reports a click event on this widget; its argument is simply a table wit all
+each time the i3 barlib reports a click event on this widget; its argument is simply a table with all
 the click properties reported by i3bar; see <a href="/docs/i3bar-protocol.html#_click_events">i3bar protocol § Click events</a>.
 (Although note that <code>name</code> is excluded as it is set automatically and is meaningless to the widget;
 in order to find out which segment was clicked, set the <code>instance</code> property on segments in

--- a/docs/user-contributed/lzap-config.html
+++ b/docs/user-contributed/lzap-config.html
@@ -20,7 +20,7 @@ group: Docs
 
 <p>Please note dunst is not in Fedora 17 repositories, but I have created a <a href='https://bugzilla.redhat.com/show_bug.cgi?id=852211'>review request</a>. Feel free to take it for review.</p>
 
-<p>Exit your desktop environment or window manager and log on into i3 from the GDM menu (if you use it). i3 will ask to create initial configuration during the first start. Say yes and do not worry - reloading/restarting i3 is fluent and you can do this zillions of times without loosing a single window.</p>
+<p>Exit your desktop environment or window manager and log on into i3 from the GDM menu (if you use it). i3 will ask to create initial configuration during the first start. Say yes and do not worry - reloading/restarting i3 is fluent and you can do this zillions of times without losing a single window.</p>
 
 <h2 id='i3_configuration'>i3 configuration</h2>
 
@@ -28,7 +28,7 @@ group: Docs
 
 <pre><tt>set $mod Mod4</tt></pre>
 
-<p>i3 works best with a modifier key set to ALT (Mod1) or WIN (Mod4). I have a windows key on my keyboard unused anyway, so I use it as my main modifier key (with few exceptions bellow).</p>
+<p>i3 works best with a modifier key set to ALT (Mod1) or WIN (Mod4). I have a windows key on my keyboard unused anyway, so I use it as my main modifier key (with few exceptions below).</p>
 
 <pre><tt># font for window titles. ISO 10646 = Unicode
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1</tt></pre>
@@ -360,7 +360,7 @@ xset -b &amp;</tt></pre>
 
 <p>Don&#8217;t like PC-speaker beeping at all.</p>
 
-<pre><tt>## Keybord layout setting
+<pre><tt>## Keyboard layout setting
 setxkbmap -layout cz,us -option grp:shift_shift_toggle &amp;</tt></pre>
 
 <p>I told you &#8211; Czech layout.</p>

--- a/docs/user-contributed/workspace-current-output.html
+++ b/docs/user-contributed/workspace-current-output.html
@@ -104,7 +104,7 @@ bindsym $mod+asterisk exec --no-startup-id ~/.config/i3/switch-workspace.py 10
 <li><a href="https://github.com/ziberna/i3-py">Python i3-ipc bindings</a></li>
 <li><a href="/docs/user-contributed/swapping-workspaces.html">Swapping workspaces</a></li>
 <li><a href="/docs/ipc.html">IPC interface</a></li>
-<li>A bug repport explaining <a href="http://bugs.i3wm.org/report/ticket/809">how to make the focus follow the moved workspace</a></li>
+<li>A bug report explaining <a href="http://bugs.i3wm.org/report/ticket/809">how to make the focus follow the moved workspace</a></li>
 </ul>
 
 <p>Author: <a href="http://captnfab.chezlefab.net/">captnfab</a>, 2014-08-02</p>

--- a/docs/userguide.html
+++ b/docs/userguide.html
@@ -1561,7 +1561,7 @@ bindsym Mod1+F fullscreen toggle</tt></pre>
 <div class="paragraph"><p>Since i3 4.24, you can configure a modifier key which, when pressed, will swap
 instead of moving containers when dropping directly onto another container.
 Defaults to <tt>Shift</tt>. Note that you have to be pressing both the floating
-modifer and the swap modifier before the drag is initiated.</p></div>
+modifier and the swap modifier before the drag is initiated.</p></div>
 <div class="paragraph"><p><strong>Syntax</strong>:</p></div>
 <div class="listingblock">
 <div class="content">

--- a/i3bar/manpage.html
+++ b/i3bar/manpage.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }


### PR DESCRIPTION
There are some typos in the documentation.
Fix them via codespell.